### PR TITLE
refactor(judge): modernize LLMJudgeReward invocation and slim its surface

### DIFF
--- a/examples/eval/browsecomp/chat_env.py
+++ b/examples/eval/browsecomp/chat_env.py
@@ -35,7 +35,7 @@ def create_env_factory(model_config: dict, **env_config):
                 sampling_params={"max_new_tokens": 1024},
             )()
         )
-    reward_fn = BrowseCompReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
+    reward_fn = BrowseCompReward(judge_model=judge_models)
 
     async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)

--- a/examples/eval/browsecomp/web_search_env.py
+++ b/examples/eval/browsecomp/web_search_env.py
@@ -40,7 +40,7 @@ def create_env_factory(model_config: dict, **env_config):
                 sampling_params={"max_new_tokens": 1024},
             )()
         )
-    reward_fn = BrowseCompReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
+    reward_fn = BrowseCompReward(judge_model=judge_models)
 
     async def env_factory():
         return WebSearchEnv(

--- a/examples/eval/frames/chat_env.py
+++ b/examples/eval/frames/chat_env.py
@@ -35,7 +35,7 @@ def create_env_factory(model_config: dict, **env_config):
                 sampling_params={"max_new_tokens": 1024},
             )()
         )
-    reward_fn = FramesReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
+    reward_fn = FramesReward(judge_model=judge_models)
 
     async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)

--- a/examples/eval/hle_verified/chat_env.py
+++ b/examples/eval/hle_verified/chat_env.py
@@ -41,7 +41,7 @@ def create_env_factory(model_config: dict, **env_config):
                 sampling_params={"max_new_tokens": 2048},
             )()
         )
-    reward_fn = HLEReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
+    reward_fn = HLEReward(judge_model=judge_models)
 
     async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)

--- a/examples/eval/mcp_atlas/env.py
+++ b/examples/eval/mcp_atlas/env.py
@@ -34,15 +34,13 @@ def create_env_factory(model_config: dict, **env_config):
                 sampling_params={"max_new_tokens": 1024},
             )()
         )
-    max_judge_retries = env_config.get("max_judge_retries", 3)
-
     docker_url = env_config.get("docker_url", MCPAtlasEnv.DEFAULT_DOCKER_URL)
     http_client = MCPAtlasEnv.create_client(base_url=docker_url)
 
     async def env_factory():
         # Each env gets its own reward_fn to avoid concurrent tasks overwriting
         # _current_claim / _response on a shared instance.
-        reward_fn = MCPAtlasReward(judge_model=judge_models, max_model_retries=max_judge_retries)
+        reward_fn = MCPAtlasReward(judge_model=judge_models)
         return MCPAtlasEnv(
             model_factory=model_factory,
             http_client=http_client,

--- a/examples/eval/sealqa/chat_env.py
+++ b/examples/eval/sealqa/chat_env.py
@@ -35,7 +35,7 @@ def create_env_factory(model_config: dict, **env_config):
                 sampling_params={"max_new_tokens": 1024},
             )()
         )
-    reward_fn = SealQAReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
+    reward_fn = SealQAReward(judge_model=judge_models)
 
     async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)

--- a/examples/eval/simpleqa_verified/chat_env.py
+++ b/examples/eval/simpleqa_verified/chat_env.py
@@ -35,7 +35,7 @@ def create_env_factory(model_config: dict, **env_config):
                 sampling_params={"max_new_tokens": 1024},
             )()
         )
-    reward_fn = SimpleQAReward(judge_model=judge_models, max_model_retries=env_config.get("max_judge_retries", 3))
+    reward_fn = SimpleQAReward(judge_model=judge_models)
 
     async def env_factory():
         return Environment(model_factory=model_factory, reward_fn=reward_fn, **env_config)

--- a/src/strands_env/core/llm_judge_reward.py
+++ b/src/strands_env/core/llm_judge_reward.py
@@ -19,15 +19,14 @@ from __future__ import annotations
 import itertools
 import logging
 from abc import abstractmethod
-from typing import Generic, override
+from typing import Generic, cast, override
 
 from pydantic import BaseModel
 from strands import Agent
 from strands.models import Model
-from strands.types.exceptions import ModelThrottledException
 from typing_extensions import TypeVar
 
-from .types import RewardFunction, RewardResult, RolloutResult, TaskT
+from .types import RewardFunction, RewardResult, RolloutResult, TaskT, extract_message_text
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +40,9 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
     Args:
         judge_model: A single model or a list of models to round-robin across
             (useful for spreading load across AWS profiles to avoid throttling).
-        system_prompt: Optional system prompt for the judge.
+            The cycle advances per sample, so consecutive judgments hit different
+            profiles.
         default_reward: Reward to return if the judge fails.
-        max_model_retries: Max retries on `ModelThrottledException`, cycling
-            through the `judge_model` list.  This is complementary to Strands'
-            built-in exponential-backoff retry, as outer, model-level retries.
 
     Notes:
         - Subclasses set `judgment_format` class attribute and implement
@@ -53,6 +50,11 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
         - When `judgment_format` is set, uses structured output and passes
           the parsed Pydantic model to `get_reward`. When `None`, passes
           the raw text response instead.
+        - Throttling is handled by Strands' `ModelRetryStrategy`, a default hook on
+          every `Agent`: 6 attempts with exponential backoff (`4+8+16+32+64` = ~124s)
+          before a `ModelThrottledException` surfaces here as `judge_error`. Override
+          `get_judge_agent` to tune it (`retry_strategy=ModelRetryStrategy(...)`), or
+          to add a hook that rotates `agent.model` between attempts.
 
     Example:
         class SimpleQAReward(LLMJudgeReward[SimpleQAJudgment]):
@@ -72,16 +74,14 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
         self,
         judge_model: Model | list[Model],
         *,
-        system_prompt: str | None = None,
         default_reward: float = 0.0,
-        max_model_retries: int = 1,
     ) -> None:
-        if max_model_retries < 1:
-            raise ValueError(f"max_model_retries must be >= 1, got {max_model_retries}")
         self.judge_models = itertools.cycle(judge_model if isinstance(judge_model, list) else [judge_model])
-        self.system_prompt = system_prompt
         self.default_reward = default_reward
-        self.max_model_retries = max_model_retries
+
+    async def get_system_prompt(self, task: TaskT, result: RolloutResult) -> str | None:
+        """Return the system prompt for the judge. Override to set one, or for per-sample prompts."""
+        return None
 
     @abstractmethod
     async def get_judge_prompt(self, task: TaskT, result: RolloutResult) -> str:
@@ -93,13 +93,12 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
         """Get reward from judgment (structured or text)."""
         raise NotImplementedError("Subclasses must implement this method.")
 
-    async def get_system_prompt(self, task: TaskT, result: RolloutResult) -> str | None:
-        """Return the system prompt for the judge. Override for per-sample prompts."""
-        return self.system_prompt
+    async def get_judge_agent(self, system_prompt: str | None, name: str = "LLMJudge") -> Agent:
+        """Build the agent that judges one sample. Override to configure it."""
+        return Agent(model=next(self.judge_models), system_prompt=system_prompt, tools=[], name=name)
 
     @override
     async def compute(self, task: TaskT, result: RolloutResult) -> RewardResult:
-
         def _render_error(e: Exception) -> str:
             return f"{type(e).__name__}: {e}"
 
@@ -123,29 +122,21 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
                 info={"status": "error", "error_type": "judge_prompt_error", "error": _render_error(e)},
             )
 
-        # Invoke judge model with retry
-        for attempt in range(self.max_model_retries):
-            agent = Agent(model=next(self.judge_models), system_prompt=system_prompt, tools=[], name="LLMJudge")
-            try:
-                if self.judgment_format is not None:
-                    judgment: JudgmentFormat | str = await agent.structured_output_async(
-                        output_model=self.judgment_format, prompt=prompt
-                    )
-                else:
-                    judge_result = await agent.invoke_async(prompt)
-                    judgment = judge_result.message.get("content", [{}])[0].get("text", "")
-                break
-            except Exception as e:
-                if isinstance(e, ModelThrottledException) and attempt < self.max_model_retries - 1:
-                    logger.warning(
-                        "Judge model throttled (attempt %d/%d), retrying", attempt + 1, self.max_model_retries
-                    )
-                    continue
-                logger.error("Judge model invocation failed: %s", e)
-                return RewardResult(
-                    reward=self.default_reward,
-                    info={"status": "error", "error_type": "judge_error", "error": _render_error(e)},
-                )
+        # Invoke judge model (Strands' `ModelRetryStrategy` handles throttling internally)
+        try:
+            agent = await self.get_judge_agent(system_prompt)
+            judge_result = await agent.invoke_async(prompt, structured_output_model=self.judgment_format)
+            judgment: JudgmentFormat | str = (
+                cast(JudgmentFormat, judge_result.structured_output)
+                if self.judgment_format is not None
+                else extract_message_text(judge_result.message)
+            )
+        except Exception as e:
+            logger.error("Judge model invocation failed: %s", e)
+            return RewardResult(
+                reward=self.default_reward,
+                info={"status": "error", "error_type": "judge_error", "error": _render_error(e)},
+            )
 
         # Get reward
         judgment_data = judgment.model_dump(mode="json") if isinstance(judgment, BaseModel) else judgment

--- a/src/strands_env/environments/tau2_bench/nl_judge.py
+++ b/src/strands_env/environments/tau2_bench/nl_judge.py
@@ -79,8 +79,13 @@ class Tau2BenchNLAssertionReward(LLMJudgeReward[NLJudgment, Tau2BenchTask]):
     judgment_format = NLJudgment
 
     def __init__(self, env: Tau2BenchEnv, judge_model: Model | list[Model]) -> None:
-        super().__init__(judge_model=judge_model, system_prompt=NL_JUDGE_SYSTEM_PROMPT)
+        super().__init__(judge_model=judge_model)
         self._env = env
+
+    @override
+    async def get_system_prompt(self, task: Tau2BenchTask, result: RolloutResult) -> str:
+        """Return tau2's NL-assertion judge prompt."""
+        return NL_JUDGE_SYSTEM_PROMPT
 
     @override
     async def get_judge_prompt(self, task: Tau2BenchTask, result: RolloutResult) -> str:

--- a/tests/unit/core/test_llm_judge_reward.py
+++ b/tests/unit/core/test_llm_judge_reward.py
@@ -16,7 +16,6 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from pydantic import BaseModel
 from strands.types.exceptions import ModelThrottledException
 
@@ -191,9 +190,9 @@ class TestHappyPath:
     async def test_structured_output_success(self, mock_agent_cls):
         """Structured output mode: judgment_format set, structured output parsed."""
         mock_agent_instance = MagicMock()
-        mock_agent_instance.structured_output_async = AsyncMock(
-            return_value=_FakeJudgment(grade="correct"),
-        )
+        mock_result = MagicMock()
+        mock_result.structured_output = _FakeJudgment(grade="correct")
+        mock_agent_instance.invoke_async = AsyncMock(return_value=mock_result)
         mock_agent_cls.return_value = mock_agent_instance
 
         judge = _StructuredJudge(judge_model=MagicMock())
@@ -222,35 +221,46 @@ class TestHappyPath:
         assert result.info["judgment"] == "correct answer"
 
     @patch("strands_env.core.llm_judge_reward.Agent")
-    async def test_throttle_rotates_to_next_model(self, mock_agent_cls):
-        """On throttle, cycles to the next model and succeeds."""
+    async def test_model_list_rotates_per_sample(self, mock_agent_cls):
+        """A `judge_model` list round-robins across samples, spreading load over profiles."""
         mock_result = MagicMock()
         mock_result.message = {"content": [{"text": "correct"}]}
-        throttled = MagicMock(invoke_async=AsyncMock(side_effect=ModelThrottledException("throttled")))
-        ok = MagicMock(invoke_async=AsyncMock(return_value=mock_result))
-        mock_agent_cls.side_effect = [throttled, ok]
+        mock_agent_cls.return_value = MagicMock(invoke_async=AsyncMock(return_value=mock_result))
 
         model_a, model_b = MagicMock(), MagicMock()
-        judge = _TextJudge(judge_model=[model_a, model_b], max_model_retries=2)
-        result = await judge.compute(*_task_and_result())
+        judge = _TextJudge(judge_model=[model_a, model_b])
+        for _ in range(3):
+            await judge.compute(*_task_and_result())
 
-        assert result.reward == 1.0
-        assert mock_agent_cls.call_args_list[0][1]["model"] is model_a
-        assert mock_agent_cls.call_args_list[1][1]["model"] is model_b
+        used = [call[1]["model"] for call in mock_agent_cls.call_args_list]
+        assert used == [model_a, model_b, model_a]
 
     @patch("strands_env.core.llm_judge_reward.Agent")
-    async def test_all_retries_throttled_returns_default(self, mock_agent_cls):
-        """When all retries exhausted, returns default_reward."""
+    async def test_throttle_returns_default_reward(self, mock_agent_cls):
+        """A throttle surfacing from Strands' own retry is reported as judge_error."""
         throttled = MagicMock(invoke_async=AsyncMock(side_effect=ModelThrottledException("throttled")))
         mock_agent_cls.return_value = throttled
 
-        judge = _TextJudge(judge_model=MagicMock(), max_model_retries=2, default_reward=0.0)
+        judge = _TextJudge(judge_model=MagicMock(), default_reward=0.0)
         result = await judge.compute(*_task_and_result())
 
         assert result.reward == 0.0
         assert result.info["error_type"] == "judge_error"
 
-    def test_non_positive_max_model_retries_rejected(self):
-        """max_model_retries < 1 would skip the judge loop entirely, leaving judgment unbound."""
-        with pytest.raises(ValueError, match="max_model_retries"):
-            _TextJudge(judge_model=MagicMock(), max_model_retries=0)
+    @patch("strands_env.core.llm_judge_reward.Agent")
+    async def test_get_judge_agent_override_used(self, mock_agent_cls):
+        """An overridden get_judge_agent replaces the default agent construction."""
+        mock_result = MagicMock()
+        mock_result.message = {"content": [{"text": "correct"}]}
+        custom = MagicMock(invoke_async=AsyncMock(return_value=mock_result))
+
+        class _CustomAgentJudge(_TextJudge):
+            async def get_judge_agent(self, system_prompt):
+                return custom
+
+        judge = _CustomAgentJudge(judge_model=MagicMock())
+        result = await judge.compute(*_task_and_result())
+
+        assert result.reward == 1.0
+        mock_agent_cls.assert_not_called()
+        custom.invoke_async.assert_awaited_once()


### PR DESCRIPTION
## Why

Three problems in `LLMJudgeReward`, all in the invocation path:

1. **`tools` were silently ignored in structured mode.** `compute` drove the judge through `Agent.structured_output_async`, which is deprecated and calls `model.structured_output()` directly, bypassing the event loop. Whenever `judgment_format` was set, a judge's tools never ran.
2. **A reasoning judge scored `default_reward` on correct answers.** Text-mode extraction read `message["content"][0]["text"]`, which is empty when the model emits a leading `reasoningContent` block.
3. **`max_model_retries` multiplied against Strands' own retry.** `ModelRetryStrategy` is a default hook on every `Agent` (6 attempts, `4+8+16+32+64` ≈ 124s of backoff), so an outer loop of 3 could block ~6 minutes on a throttled judge.

## What

- Move to `invoke_async(prompt, structured_output_model=...)` — one call that runs the tool loop and then forces the typed verdict. A judge can now gather evidence *and* return a structured judgment.
- Use `extract_message_text` for the text path: last text block, `<think>` stripped.
- Add `get_judge_agent(system_prompt, name="LLMJudge")` as the seam for agent construction. The base returns the toolless agent; overrides attach tools, hooks (e.g. a `LoopLimiter` budget), or a `retry_strategy`. The per-sample system prompt arrives already resolved, so an override cannot silently drop it.
- Drop two constructor params now covered by the hook:
  - **`system_prompt`** — most judge subclasses never used it and two override `get_system_prompt` instead. `tau2_bench`, the one real user, moves its constant to a `get_system_prompt` override.
  - **`max_model_retries`** — load spreading does not depend on it: `judge_models` is a shared `itertools.cycle`, so each *sample* already advances to the next profile, which is what the eval hooks want. Within-sample failover, if ever needed, belongs in `get_judge_agent` via a hook that swaps `agent.model` on throttle.

## Breaking changes

`LLMJudgeReward.__init__` no longer accepts `system_prompt` or `max_model_retries`. Callers passing either need updating:

- `system_prompt=...` → override `get_system_prompt`.
- `max_model_retries=...` → drop it; Strands' `ModelRetryStrategy` already retries, and a `judge_model` list still round-robins per sample.

The 7 `examples/eval/*` hooks that plumbed `max_judge_retries` are updated here. `get_system_prompt` now returns `None` by default instead of `self.system_prompt`.

No dependency change: `invoke_async(structured_output_model=...)` predates the existing `strands-agents>=1.46.0` floor, and `structured_output_async` is already deprecated at that version.

## Testing

- `ruff check --no-fix` + `ruff format --check` clean (148 files); `mypy src/` clean (71 files); `pytest tests/unit` → 301 passed.
- Test updates: structured-path mock moves to `invoke_async`; the two throttle-retry tests and the `max_model_retries < 1` validation test are replaced by per-sample model rotation, throttle → `judge_error`, and a `get_judge_agent` override test.
- Exercised against Bedrock (claude-sonnet-4-5) on both the structured and text paths, plus a tool-using structured judge — evidence tool call followed by a typed verdict in a single invocation.

## Note

`environments/web_search/tools/scrape.py` still calls the deprecated `structured_output_async`. Out of scope here; worth a follow-up.