### PR TITLE
fix(web_search): drive the summarizer through invoke_async

### DIFF
--- a/src/strands_env/environments/web_search/tools/scrape.py
+++ b/src/strands_env/environments/web_search/tools/scrape.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import aiohttp
 import tiktoken
@@ -169,7 +169,9 @@ class WebScraperToolkit:
         prompt = SUMMARY_PROMPT_TEMPLATE.format(content=content, goal=goal)
         summarizer = Agent(model=self.summarizer_model_factory(), tools=[])
         try:
-            return await summarizer.structured_output_async(output_model=WebPageSummary, prompt=prompt)
+            result = await summarizer.invoke_async(prompt, structured_output_model=WebPageSummary)
+            # `structured_output` is unset if the model never emitted the tool call.
+            return cast(WebPageSummary | None, result.structured_output)
         except Exception as e:
             logger.error("[web_page_summary] error: content=%s..., goal=%s..., error=%s", content[:100], goal[:100], e)
             return None

--- a/tests/unit/environments/web_search/test_scrape.py
+++ b/tests/unit/environments/web_search/test_scrape.py
@@ -331,3 +331,59 @@ class TestScraperDefaults:
 
         sig = inspect.signature(WebScraperToolkit.fetch_html)
         assert sig.parameters["max_retries"].default == 8
+
+
+class TestSummarize:
+    """`summarize` drives the summarizer agent and unwraps its structured output."""
+
+    @pytest.mark.asyncio
+    @patch("strands_env.environments.web_search.tools.scrape.Agent")
+    async def test_returns_structured_output(self, mock_agent_cls):
+        """The parsed `WebPageSummary` comes off `AgentResult.structured_output`."""
+        summary = WebPageSummary(rationale="R", evidence="E", summary="S")
+        mock_result = MagicMock(structured_output=summary)
+        mock_agent_cls.return_value = MagicMock(invoke_async=AsyncMock(return_value=mock_result))
+
+        toolkit = WebScraperToolkit(summarizer_model_factory=MagicMock())
+        assert await toolkit.summarize("content", "goal") is summary
+
+    @pytest.mark.asyncio
+    @patch("strands_env.environments.web_search.tools.scrape.Agent")
+    async def test_forces_structured_output_in_one_invocation(self, mock_agent_cls):
+        """The model is requested via `invoke_async`, so the event loop (and tools) run."""
+        mock_result = MagicMock(structured_output=WebPageSummary(rationale="R", evidence="E", summary="S"))
+        agent = MagicMock(invoke_async=AsyncMock(return_value=mock_result))
+        mock_agent_cls.return_value = agent
+
+        toolkit = WebScraperToolkit(summarizer_model_factory=MagicMock())
+        await toolkit.summarize("content", "goal")
+
+        agent.invoke_async.assert_awaited_once()
+        args, kwargs = agent.invoke_async.await_args
+        assert kwargs["structured_output_model"] is WebPageSummary
+        assert "content" in args[0] and "goal" in args[0]
+
+    @pytest.mark.asyncio
+    @patch("strands_env.environments.web_search.tools.scrape.Agent")
+    async def test_unset_structured_output_returns_none(self, mock_agent_cls):
+        """If the model never emits the structured-output tool, `structured_output` is None."""
+        mock_agent_cls.return_value = MagicMock(invoke_async=AsyncMock(return_value=MagicMock(structured_output=None)))
+
+        toolkit = WebScraperToolkit(summarizer_model_factory=MagicMock())
+        assert await toolkit.summarize("content", "goal") is None
+
+    @pytest.mark.asyncio
+    @patch("strands_env.environments.web_search.tools.scrape.Agent")
+    async def test_invocation_error_returns_none(self, mock_agent_cls):
+        """A failing summarizer degrades to None rather than propagating."""
+        mock_agent_cls.return_value = MagicMock(invoke_async=AsyncMock(side_effect=RuntimeError("model down")))
+
+        toolkit = WebScraperToolkit(summarizer_model_factory=MagicMock())
+        assert await toolkit.summarize("content", "goal") is None
+
+    @pytest.mark.asyncio
+    async def test_without_summarizer_factory_raises(self):
+        """`summarize` requires a summarizer model factory."""
+        toolkit = WebScraperToolkit()
+        with pytest.raises(RuntimeError, match="summarizer_model_factory"):
+            await toolkit.summarize("content", "goal")


### PR DESCRIPTION
Follow-up to #206, which flagged this as the last remaining caller.

## Why

`WebScraperToolkit.summarize` used the deprecated `Agent.structured_output_async`. That method calls `model.structured_output()` directly and bypasses the event loop, so the summarizer agent's hooks never fire and its `tools` would be silently ignored if any were ever attached — the same class of bug fixed for `LLMJudgeReward` in #206.

## What

- `summarize` now calls `invoke_async(prompt, structured_output_model=WebPageSummary)` and reads the verdict off `AgentResult.structured_output`.
- That field is unset when the model never emits the structured-output tool call, which maps cleanly onto the existing `WebPageSummary | None` return. Callers already render the failure template on `None`, so a missing summary degrades exactly as an invocation error already does — no behavior change for the caller.

No dependency change: `invoke_async(structured_output_model=...)` predates the existing `strands-agents>=1.46.0` floor.

## Testing

`summarize` had no direct coverage — the `scrape` tests patch it wholesale — so this adds five tests for it:

- structured output is unwrapped and returned,
- the request is forced in a single `invoke_async` call (with `structured_output_model` set and the prompt carrying content + goal),
- unset `structured_output` returns `None`,
- a failing invocation returns `None`,
- the missing-`summarizer_model_factory` guard raises.

`ruff check --no-fix` + `ruff format --check` clean (148 files); `mypy src/` clean (71 files); `pytest tests/unit` → 306 passed (301 + 5 new).

This leaves no callers of `structured_output_async` in the repo.