### PR TITLE
fix(eval): abort samples that cannot be scored, instead of counting them

### DIFF
--- a/src/strands_env/eval/benchmarks/browsecomp.py
+++ b/src/strands_env/eval/benchmarks/browsecomp.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field
 from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 
-from ..evaluator import EvalSample, Evaluator
+from ..evaluator import Evaluator
 from ..registry import register_eval
 
 logger = logging.getLogger(__name__)
@@ -98,14 +98,6 @@ class BrowseCompReward(LLMJudgeReward[BrowseCompJudgment]):
 @register_eval("browsecomp")
 class BrowseCompEvaluator(Evaluator):
     """Evaluator for BrowseComp benchmark."""
-
-    @override
-    def validate_sample(self, sample: EvalSample) -> bool:
-        """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward_result = sample.result.reward_result
-        if reward_result is None:
-            return True
-        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/frames.py
+++ b/src/strands_env/eval/benchmarks/frames.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel, Field
 from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 
-from ..evaluator import EvalSample, Evaluator
+from ..evaluator import Evaluator
 from ..registry import register_eval
 
 logger = logging.getLogger(__name__)
@@ -88,14 +88,6 @@ class FramesEvaluator(Evaluator):
     """Evaluator for FRAMES benchmark."""
 
     hf_dataset_path = "google/frames-benchmark"
-
-    @override
-    def validate_sample(self, sample: EvalSample) -> bool:
-        """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward_result = sample.result.reward_result
-        if reward_result is None:
-            return True
-        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/hle_verified.py
+++ b/src/strands_env/eval/benchmarks/hle_verified.py
@@ -31,7 +31,7 @@ from strands.types.content import Message
 from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 
-from ..evaluator import EvalSample, Evaluator
+from ..evaluator import Evaluator
 from ..registry import register_eval
 
 logger = logging.getLogger(__name__)
@@ -121,14 +121,6 @@ class HLEVerifiedEvaluator(Evaluator):
         r"^data:image/(?P<fmt>[^;]+);base64,(?P<payload>.*)$", re.IGNORECASE
     )
     _SUPPORTED_IMAGE_FORMATS: ClassVar[frozenset[str]] = frozenset({"png", "jpeg", "gif", "webp"})
-
-    @override
-    def validate_sample(self, sample: EvalSample) -> bool:
-        """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward_result = sample.result.reward_result
-        if reward_result is None:
-            return True
-        return reward_result.info.get("status") != "error"
 
     @staticmethod
     def parse_image_data_url(data_url: str) -> tuple[Literal["png", "jpeg", "gif", "webp"], bytes]:

--- a/src/strands_env/eval/benchmarks/mcp_atlas.py
+++ b/src/strands_env/eval/benchmarks/mcp_atlas.py
@@ -92,15 +92,6 @@ class MCPAtlasEvaluator(Evaluator[MCPAtlasTask]):
                 await http_client.aclose()
 
     @override
-    def validate_sample(self, sample: EvalSample[MCPAtlasTask]) -> bool:
-        """Abort samples where reward is missing or judge failed, so they are retried on resume."""
-        reward_result = sample.result.reward_result
-        if reward_result is None:
-            # no reward_fn configured — deterministic, retrying can't help (run() warns about it)
-            return True
-        return reward_result.info.get("status") != "error"
-
-    @override
     def load_dataset(self) -> Iterable[MCPAtlasTask]:
         """Load MCP-Atlas tasks from HuggingFace, filter by available servers."""
         from datasets import load_dataset

--- a/src/strands_env/eval/benchmarks/sealqa.py
+++ b/src/strands_env/eval/benchmarks/sealqa.py
@@ -24,7 +24,7 @@ from datasets import load_dataset
 
 from strands_env.core import Task
 
-from ..evaluator import EvalSample, Evaluator
+from ..evaluator import Evaluator
 from ..registry import register_eval
 from .simpleqa_verified import SimpleQAReward
 
@@ -42,14 +42,6 @@ class SealQAEvaluator(Evaluator):
     """Base evaluator for SealQA benchmarks."""
 
     hf_dataset_path = "vtllms/sealqa"
-
-    @override
-    def validate_sample(self, sample: EvalSample) -> bool:
-        """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward_result = sample.result.reward_result
-        if reward_result is None:
-            return True
-        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/simpleqa_verified.py
+++ b/src/strands_env/eval/benchmarks/simpleqa_verified.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel, Field
 from strands_env.core import RolloutResult, Task
 from strands_env.core.llm_judge_reward import LLMJudgeReward
 
-from ..evaluator import EvalSample, Evaluator
+from ..evaluator import Evaluator
 from ..registry import register_eval
 
 logger = logging.getLogger(__name__)
@@ -147,14 +147,6 @@ class SimpleQAVerifiedEvaluator(Evaluator):
     """Base evaluator for SimpleQA-Verified benchmarks."""
 
     hf_dataset_path = "google/simpleqa-verified"
-
-    @override
-    def validate_sample(self, sample: EvalSample) -> bool:
-        """Abort samples where the judge failed (e.g. throttling), so they are retried on resume."""
-        reward_result = sample.result.reward_result
-        if reward_result is None:
-            return True
-        return reward_result.info.get("status") != "error"
 
     @override
     def load_dataset(self) -> Iterable[Task]:

--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -82,16 +82,20 @@ class Tau2BenchEvaluator(Evaluator[Tau2BenchTask]):
 
     @override
     def validate_sample(self, sample: EvalSample[Tau2BenchTask]) -> bool:
-        """Abort samples with missing reward, NL judge error, or an aborted user-sim (all retryable)."""
-        reward_result = sample.result.reward_result
-        if reward_result is None:
+        """Also abort on an NL-judge error or an aborted user-sim (both retryable).
+
+        Neither is visible to the base check: the NL judge is a sub-reward, so its failure is
+        nested in `info` instead of setting the reward's own `status`, and the user simulator
+        is not part of the reward at all.
+        """
+        if not super().validate_sample(sample):
             return False
+        reward_result = sample.result.reward_result
+        assert reward_result is not None  # the base check rejects a missing reward
         nl_judge = reward_result.info.get("nl_judge")
         if nl_judge and nl_judge.get("status") == "error":
             return False
-        if ((sample.result.metrics or {}).get("user_simulator") or {}).get("termination") == "aborted":
-            return False
-        return True
+        return ((sample.result.metrics or {}).get("user_simulator") or {}).get("termination") != "aborted"
 
     @override
     def get_metric_fns(self) -> list[MetricFunction]:

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -70,15 +70,6 @@ class TerminalBenchEvaluator(Evaluator[HarborTask]):
         return task
 
     @override
-    def validate_sample(self, sample: EvalSample[HarborTask]) -> bool:
-        """Abort samples where reward is missing or verification failed, so they are retried on resume."""
-        reward_result = sample.result.reward_result
-        if reward_result is None:
-            # no reward_fn configured — deterministic, retrying can't help (run() warns about it)
-            return True
-        return reward_result.info.get("status") != "error"
-
-    @override
     async def evaluate_sample(self, task: HarborTask) -> EvalSample[HarborTask]:
         """Override to create sample-specific output directories for pass@k."""
         sample_idx = int(task.id.rsplit("_", 1)[1]) if "_" in task.id else 0

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -112,12 +112,18 @@ class Evaluator(Generic[TaskT]):
         """Load dataset. Override in subclasses."""
         raise NotImplementedError("Subclasses must implement load_dataset()")
 
-    def validate_sample(self, _sample: EvalSample[TaskT]) -> bool:
+    def validate_sample(self, sample: EvalSample[TaskT]) -> bool:
         """Check if a completed sample is valid. Override with benchmark-specific logic.
 
-        Return False to mark the sample as aborted (excluded from metrics, retried on resume).
+        Notes:
+            - Return `True` to mark the sample as valid, `False` to mark it as aborted (excluded from metrics, retried on resume).
+            - By default a sample is invalid unless it carries a reward that computed: a
+              missing reward, or one whose `info` says `status: "error"`, cannot be scored,
+              and metrics count an unscorable sample as *incorrect* rather than absent.
+              Keeping it would report a fabricated number.
         """
-        return True
+        reward_result = sample.result.reward_result
+        return reward_result is not None and reward_result.info.get("status") != "error"
 
     def get_metric_fns(self) -> list[MetricFunction]:
         """Return metric functions for evaluation. Override to customize.

--- a/tests/unit/eval/test_evaluator.py
+++ b/tests/unit/eval/test_evaluator.py
@@ -185,8 +185,12 @@ class TestCheckpoint:
         assert len(lines) == 1
 
     async def test_resumes_from_checkpoint(self, mock_env, tmp_path):
-        """Skips already-completed samples on resume."""
-        mock_env.rollout.return_value = RolloutResult()
+        """Skips already-completed samples on resume.
+
+        The rollout carries a reward, since an unscorable sample is aborted and so retried
+        rather than skipped.
+        """
+        mock_env.rollout.return_value = RolloutResult(reward_result=RewardResult(reward=1.0))
         output_path = tmp_path / "results.jsonl"
 
         async def factory():
@@ -218,6 +222,37 @@ class TestCheckpoint:
 
 
 class TestValidateSample:
+    def _evaluator(self, tmp_path):
+        async def factory():
+            return MagicMock()
+
+        return Evaluator(env_factory=factory, output_path=tmp_path / "results.jsonl")
+
+    def test_reward_error_is_invalid_by_default(self, tmp_path):
+        """A failed reward is the `default_reward` fallback, not a measurement — abort and retry it."""
+        sample = EvalSample(
+            task=Task(id="s", message="q"),
+            result=RolloutResult(
+                reward_result=RewardResult(reward=0.0, info={"status": "error", "error_type": "judge_error"})
+            ),
+        )
+        assert self._evaluator(tmp_path).validate_sample(sample) is False
+
+    def test_successful_reward_is_valid(self, tmp_path):
+        """A scored sample is kept, including a legitimate 0.0."""
+        evaluator = self._evaluator(tmp_path)
+        for reward in (0.0, 1.0):
+            sample = EvalSample(
+                task=Task(id="s", message="q"),
+                result=RolloutResult(reward_result=RewardResult(reward=reward, info={"status": "success"})),
+            )
+            assert evaluator.validate_sample(sample) is True
+
+    def test_missing_reward_is_invalid(self, tmp_path):
+        """An unscored sample cannot be scored, and metrics would count it as incorrect."""
+        sample = EvalSample(task=Task(id="s", message="q"), result=RolloutResult())
+        assert self._evaluator(tmp_path).validate_sample(sample) is False
+
     async def test_aborted_samples_excluded_from_metrics(self, tmp_path):
         """Entire prompt is excluded from metrics if any sample is aborted."""
         results = {


### PR DESCRIPTION
## Why

`validate_sample` defaulted to `True`, so a sample the `Evaluator` could not score was kept and folded into the metrics anyway. Both scorers require a reward — `compute_pass_at_k` and `compute_pass_power_k` define `is_correct` as `r is not None and r.reward >= threshold`, so an unscorable sample is counted as *incorrect*, not absent.

Two ways to hit it:

1. **A failed reward.** `LLMJudgeReward` always returns a `RewardResult`, using `default_reward` on failure, so a throttled or unparseable judge was indistinguishable from a genuinely wrong answer: it scored 0.0, and because `reward_result` was not `None` the sample counted as complete — so resume never re-ran it. The metric looked fine and was wrong.
2. **No reward at all.** An inference-only run (no `reward_fn` configured) reported `pass@1 = 0.0` — a fabricated number rather than an absent one.

## What

Default to invalid unless the sample carries a reward that computed: not `None`, and no `status: "error"` in `info` (the marker every `RewardFunction` sets on failure). Such a reward is a fallback, not a measurement. Unscorable is unscorable however it arose, so the sample is excluded from metrics and retried on resume.

Resume is a manual step, so nothing loops on its own, and the trajectory is still written to the results file.

- **Seven benchmarks** had each copy-pasted the reward-error half of this check (`simpleqa_verified`, `sealqa`, `frames`, `browsecomp`, `hle_verified`, `mcp_atlas`, `terminal_bench`) — they now inherit it, removing the duplication.
- **`tau2_bench`** defers to the base via `super()` and keeps only what the base cannot see: the NL judge is a sub-reward, so its failure is nested in `info` rather than setting the reward's own `status`, and the user simulator is not part of the reward at all.

## Behavior change

Two cases that were previously kept are now aborted (excluded from metrics, retried on resume):

| sample | before | after |
|---|---|---|
| reward `info.status == "error"` | kept, scored `default_reward` | aborted |
| `reward_result is None` | kept, scored as incorrect | aborted |
| reward computed (incl. a real 0.0) | kept | kept |

If you run inference-only on purpose and want the samples retained, override `validate_sample` to `return True`.

## Testing

- `ruff check --no-fix` + `ruff format --check` clean (148 files); `mypy src/` clean (71 files); `pytest tests/unit` → 309 passed (306 + 3 new).
- New coverage for a default that had none: reward error aborts, successful reward is kept (including a legitimate 0.0), missing reward aborts.
- One fixture needed a reward: `test_resumes_from_checkpoint` returned a bare `RolloutResult()`, which now aborts and is therefore retried rather than skipped — exactly the new behavior, so the fixture, not the assertion, was wrong.
- Verified the `tau2_bench` refactor preserves its paths by enumerating all 24 reward/metrics shapes against the old logic: the only divergences are the reward-error rows the base now rejects. Missing reward, NL-judge error, aborted user-sim, and the passing shapes are unchanged.