### PR TITLE
fix(eval): write the run config once, through the reporter

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -290,11 +290,12 @@ Available parsers: `hermes` (default), `qwen_xml`, `glm`.
 
 ## Output Files
 
-Evaluation results are saved to the output directory:
+Evaluation results are written by the configured reporter. `LocalReporter` (the default) saves them
+to the output directory:
 
 ```
 {benchmark}_eval/
-├── config.json      # CLI configuration for reproducibility
+├── metadata.json    # Run configuration for reproducibility
 ├── results.jsonl    # Per-sample results (task, result, reward)
 └── metrics.json     # Aggregated metrics (pass@k, etc.)
 ```

--- a/src/strands_env/eval/cli.py
+++ b/src/strands_env/eval/cli.py
@@ -282,27 +282,18 @@ def eval_cmd(
     )
     tasks = list(evaluator.load_dataset())[:max_samples]
 
-    # Save config for reproducibility
-    config_data = {
+    mode = f"distributed ({n_actors_per_node} actors/node)" if env_actor_pool else "local"
+    click.echo(
+        f"Running {benchmark_name} | {backend} | {model_id or '(auto)'} | "
+        f"{len(tasks)} samples | n={n_samples_per_prompt} | concurrency={max_concurrency} | {mode} | {output_dir}"
+    )
+    metadata = {
         "benchmark": benchmark_name,
         "evaluator_path": evaluator_path,
         "env_hook": env_hook,
         "env_config": env_config or {},
         "model_config": model_config.to_dict(),
         "n_actors_per_node": n_actors_per_node,
-    }
-    with open(output_dir / "config.json", "w", encoding="utf-8") as f:
-        json.dump(config_data, f, indent=2)
-
-    mode = f"distributed ({n_actors_per_node} actors/node)" if env_actor_pool else "local"
-    click.echo(
-        f"Running {benchmark_name} | {backend} | {model_id or '(auto)'} | "
-        f"{len(tasks)} samples | n={n_samples_per_prompt} | concurrency={max_concurrency} | {mode} | {output_dir}"
-    )
-
-    # Run-level metadata for reporters (params/tags for MLflow-style sinks, mirrors config.json).
-    run_metadata = {
-        **config_data,
         "backend": backend,
         "model_id": model_id,
         "n_samples_per_prompt": n_samples_per_prompt,
@@ -312,7 +303,7 @@ def eval_cmd(
 
     # Run, compute metrics, and publish through the reporter
     async def _run_eval() -> None:
-        evaluator.reporter.log_metadata(run_metadata)
+        evaluator.reporter.log_metadata(metadata)
         results = await evaluator.run(tasks)
         metrics = evaluator.compute_metrics(results)
         evaluator.reporter.log_metrics(metrics)


### PR DESCRIPTION
## Why

`cli.py` serialized the run configuration twice, into the same directory, under two names:

```python
config_data = {...}
with open(output_dir / "config.json", "w") as f:   # write #1
    json.dump(config_data, f, indent=2)

run_metadata = {**config_data, ...}                # strict superset
evaluator.reporter.log_metadata(run_metadata)      # write #2 -> metadata.json
```

`run_metadata` spreads `config_data`, so `metadata.json` already contained every byte of
`config.json`. A default run dropped two files where one is contained in the other.

The direct `open()` is the half to drop. #203 made the reporter the owner of result output, but this
write bypassed it — so a run configured with a remote-only reporter still got a stray local
`config.json` written behind its back, in a directory it otherwise never touches.

## What

- Remove the `config.json` write. The CLI no longer touches the filesystem; the configured reporter
  is the only sink, and `LocalReporter` writes `metadata.json` (as it has since #203).
- Keep the flat `backend` / `model_id` / `mode` keys even though they are derivable from
  `model_config` / `n_actors_per_node` — experiment-tracking sinks generally take scalar params, not
  nested dicts, so the flattening is load-bearing rather than redundant.
- `docs/evaluation.md` documented `config.json` in the output-layout tree; updated to `metadata.json`
  and noted that the layout is `LocalReporter`'s, not a fixed property of every run.

## Behavior change

`config.json` is no longer written. Its content is in `metadata.json`, so the default output
directory loses a file that only ever duplicated another. Anything reading `config.json` should read
`metadata.json` instead — no repo consumers found (`grep`: only the docs line updated here).

## Testing

`ruff check` + `ruff format --check` clean; `pytest tests/unit` → 275 passed, 3 skipped.
`mypy src/strands_env` shows only the 5 pre-existing boto3-stubs phantoms in `utils/aws.py` and
`environments/agentcore_code/tool.py` (CI installs no stubs, so `boto3` is `Any` there) — nothing in
`eval/`. No test asserted on `config.json`, so none needed updating; `test_reporter.py` already
covers `log_metadata` writing `metadata.json`.
