### PR TITLE
chore: require strands-sglang>=0.6.0 and move off /get_model_info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ pytest tests/unit/core/test_environment.py::TestRollout::test_successful_rollout
 # Unit tests with coverage
 pytest tests/unit/ -v --cov=src/strands_env --cov-report=html
 
-# Integration tests (requires running SGLang server; model ID auto-detected via /get_model_info)
+# Integration tests (requires running SGLang server; model ID auto-detected via /model_info)
 # Tests skip automatically if server is unreachable (/health check)
 pytest tests/integration/ -v --sglang-base-url=http://localhost:30000
 # Or via env var: SGLANG_BASE_URL=http://localhost:30000 pytest tests/integration/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-sglang>=0.5.0",
+    "strands-sglang>=0.6.0",
     "strands-agents[openai]>=1.46.0",
     "strands-agents-tools>=0.2.0",
     "openai",

--- a/src/strands_env/core/models.py
+++ b/src/strands_env/core/models.py
@@ -123,13 +123,13 @@ def check_server_health(base_url: str, timeout: float = 5.0) -> None:
 
 
 def get_model_id(base_url: str, timeout: float = 5.0) -> str:
-    """Get the model's HF identifier from the SGLang server via `/get_model_info`."""
-    response = httpx.get(f"{base_url}/get_model_info", timeout=timeout)
+    """Get the model's HF identifier from the SGLang server via `/model_info`."""
+    response = httpx.get(f"{base_url}/model_info", timeout=timeout)
     response.raise_for_status()
     info = response.json()
     model_id = info.get("tokenizer_path") or info.get("model_path")
     if not model_id:
-        raise RuntimeError(f"No tokenizer_path/model_path at {base_url}/get_model_info")
+        raise RuntimeError(f"No tokenizer_path/model_path at {base_url}/model_info")
     return str(model_id)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,7 @@
 """Shared fixtures for integration tests.
 
 All tests in this directory require a running SGLang server.
-The model ID is auto-detected from the server via /get_model_info.
+The model ID is auto-detected from the server via /model_info.
 Tests are skipped automatically if the server is not reachable.
 
 Configuration (priority: CLI > env var > default):


### PR DESCRIPTION
## What

- Bump the `strands-sglang` floor from `>=0.5.0` to `>=0.6.0`.
- Point `get_model_id()` at SGLang's `/model_info` instead of the deprecated `/get_model_info`, and
  update the two doc mentions (`CLAUDE.md`, `tests/integration/conftest.py`).

## Why the endpoint change rides along

strands-sglang 0.6.0 moved its own callers to `/model_info` because `/get_model_info` is deprecated
upstream and logs a warning on every call. `get_model_id()` issues its own `httpx` request rather
than going through the library, so the version bump alone would have left it on the old name — and it
drives model auto-detection for every integration fixture, so the upstream removal would take the
whole suite down at once.

Both endpoints currently return byte-identical JSON, verified against a live server:

```
$ curl -s localhost:30000/model_info
{"model_path":"Qwen/Qwen3.5-4B","tokenizer_path":"Qwen/Qwen3.5-4B",...}
$ curl -s localhost:30000/get_model_info      # identical
{"model_path":"Qwen/Qwen3.5-4B","tokenizer_path":"Qwen/Qwen3.5-4B",...}
```

So this is a rename ahead of the removal, not a behavior change. No `/get_model_info` references
remain in the repo.

## Why nothing else in 0.6.0 needs changes here

- **`rollout_history`** — only matters when a conversation manager trims mid-episode. Nothing
  overrides `Environment.get_conversation_manager()`, so every env runs `NullConversationManager` and
  a single `model.rollout` remains the whole trajectory.
- **`context_window_limit` on `SGLangConfig`** — additive; we don't set it, and the fallback is
  unchanged.
- **`strands-agents>=1.46.0`** — already our floor.

## Testing

Against `strands-sglang` 0.6.0 (`strands-agents` 1.52.0):

- `pytest tests/unit/` → **275 passed, 3 skipped**
- `ruff check` + `ruff format --check` clean (177 files); `mypy src/strands_env` clean (71 files)
- `pytest tests/integration/ --sglang-base-url=http://localhost:30000 --tool-parser=qwen_xml`
  against a live SGLang server (Qwen3.5-4B) → **11 passed, 5 skipped**. The skips are the
  credential-gated `web_search` tests (no `SERPER_API_KEY` / Google keys); every SGLang-backed test
  passed, and each resolves its model through the changed `get_model_id()` call.
- Called `get_model_id()` directly against the live server: returns `Qwen/Qwen3.5-4B`.

Note for anyone reproducing: the first `uv pip install` may fail with `only strands-sglang<=0.5.1 is
available` from a stale index cache — `--refresh-package strands-sglang` clears it.