### PR TITLE
fix(eval): stop an unpaired surrogate from killing an eval run

### DIFF
--- a/src/strands_env/eval/reporter.py
+++ b/src/strands_env/eval/reporter.py
@@ -160,7 +160,9 @@ class LocalReporter(EvalReporter):
         fh = self._ensure_open()
         data = sample.model_dump()
         data["prompt_id"] = prompt_id
-        fh.write(json.dumps(data, ensure_ascii=False) + "\n")
+        # `ensure_ascii` stays at its default: it escapes unpaired surrogates, which the file's
+        # UTF-8 encoder would otherwise reject mid-run.
+        fh.write(json.dumps(data) + "\n")
 
     def flush(self) -> None:
         """Sync the open file handle to disk."""
@@ -182,7 +184,7 @@ class LocalReporter(EvalReporter):
                 for sample in samples:
                     data = sample.model_dump()
                     data["prompt_id"] = prompt_id
-                    f.write(json.dumps(data, ensure_ascii=False) + "\n")
+                    f.write(json.dumps(data) + "\n")
 
     def log_metrics(self, metrics: dict[str, float]) -> None:
         """Write `metrics.json` to the output directory."""

--- a/tests/unit/eval/test_reporter.py
+++ b/tests/unit/eval/test_reporter.py
@@ -72,6 +72,21 @@ class TestLocalReporter:
         assert rows[0]["task"]["id"] == "p1_0"
         assert rows[0]["result"]["reward_result"]["reward"] == 1.0
 
+    def test_log_sample_survives_an_unpaired_surrogate(self, tmp_path: Path):
+        """A lone surrogate in model output must not fail the write."""
+        output_path = tmp_path / "results.jsonl"
+        reporter = LocalReporter(output_path)
+        sample = EvalSample(
+            task=Task(id="p1_0", message="half a math-italic code point: \ud835"),
+            result=RolloutResult(reward_result=RewardResult(reward=1.0)),
+        )
+
+        reporter.log_sample("p1", sample)
+        reporter.flush()
+
+        rows = _read_jsonl(output_path)
+        assert rows[0]["task"]["message"] == "half a math-italic code point: \ud835"
+
     def test_log_sample_creates_parent_dirs(self, tmp_path: Path):
         """The first log_sample creates parent directories if they don't exist."""
         output_path = tmp_path / "nested" / "dir" / "results.jsonl"


### PR DESCRIPTION
## Why

`LocalReporter` serialized samples with `ensure_ascii=False`. `json.dumps` accepts a lone UTF-16
surrogate; the UTF-8 encoder underneath the file does not:

```python
>>> json.dumps({"m": "\ud835"}, ensure_ascii=False).encode("utf-8")
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud835': surrogates not allowed
```

So the failure lands at `fh.write`, not at `json.dumps` — and `log_sample` is called from inside the
`asyncio.gather` in `Evaluator.run`. One bad character therefore fails the *whole run* and loses
every sample still in flight, not just the offending line. A single `\ud835` (half a math-italic
code point) in a model response is enough; models emit these when a surrogate pair gets split
mid-token.

`rewrite()` has the same call, and it is the worse of the two: it reserializes every kept sample, so
one bad character there takes the entire file rather than one write.

## What

Drop the argument at both call sites. `ensure_ascii` defaults to `True`, which escapes the surrogate
to a `\ud835` sequence — still valid JSON, and `json.loads` round-trips it back to the same string.

`ensure_ascii=False` was never load-bearing. It came over verbatim when `LocalReporter` was
extracted from `Evaluator`, and only buys readability of the raw file: non-ASCII content (CJK
product titles, star glyphs, typographic dashes) shows up escaped instead of literal. Every consumer
reads the file through `json.loads`, where escaping is invisible, and the size cost is under 1% on a
representative run. A slightly less greppable file is worth a write that cannot fail.

## Behavior change

`results.jsonl` lines are now ASCII-escaped. Content is unchanged through `json.loads`; only code
that byte-greps the raw file for literal non-ASCII text would notice.

## Testing

New `test_log_sample_survives_an_unpaired_surrogate` pins the reason the argument is absent, since
the call site no longer shows it. It is load-bearing: restoring `ensure_ascii=False` fails it with
the exact production `UnicodeEncodeError` and fails nothing else (verified by reverting locally).

`ruff check --no-fix` + `ruff format --check` clean; `mypy src/strands_env/eval/reporter.py` clean;
`pytest tests/unit` → 310 passed.