### PR TITLE
fix(eval): keep a Task subclass's own fields in results.jsonl

### DIFF
--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -26,7 +26,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Generic
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SerializeAsAny
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 class EvalSample(BaseModel, Generic[TaskT]):
     """Evaluation sample result."""
 
-    task: TaskT = Field(..., description="The task that was evaluated.")
+    task: SerializeAsAny[TaskT] = Field(..., description="The task that was evaluated.")
     result: RolloutResult = Field(..., description="The rollout result.")
     aborted: bool = Field(default=False, description="Whether this sample was aborted.")
 

--- a/tests/unit/eval/test_evaluator.py
+++ b/tests/unit/eval/test_evaluator.py
@@ -14,6 +14,7 @@
 
 """Unit tests for evaluation module (evaluator + metrics)."""
 
+import json
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -183,6 +184,30 @@ class TestCheckpoint:
         assert output_path.exists()
         lines = output_path.read_text().strip().split("\n")
         assert len(lines) == 1
+
+    async def test_checkpoint_keeps_typed_task_fields(self, mock_env, tmp_path):
+        """A `Task` subclass's own fields must reach `results.jsonl`.
+
+        The call sites construct a bare `EvalSample(...)`, so an `Evaluator[XxxTask]` binding
+        never reaches it and pydantic serializes `task` against `TaskT`'s default (`Task`) —
+        silently dropping subclass fields. The rollout still gets the real object, so this is
+        invisible at run time and only shows up in the results file and on resume.
+        """
+
+        class TypedTask(Task):
+            task_dir: str = ""
+
+        mock_env.rollout.return_value = RolloutResult(reward_result=RewardResult(reward=1.0))
+        output_path = tmp_path / "results.jsonl"
+
+        async def factory():
+            return mock_env
+
+        evaluator = Evaluator(env_factory=factory, output_path=output_path, save_interval=1)
+        await evaluator.run([TypedTask(id="s1", message="q1", task_dir="/tasks/t1")])
+
+        row = json.loads(output_path.read_text().strip())
+        assert row["task"]["task_dir"] == "/tasks/t1"
 
     async def test_resumes_from_checkpoint(self, mock_env, tmp_path):
         """Skips already-completed samples on resume.


### PR DESCRIPTION
`EvalSample.task` was annotated as a bare `TaskT`, and both call sites (`evaluator.py:196,203`) construct an unparameterized `EvalSample(...)`. An `Evaluator[XxxTask]` binding lives on the evaluator and does not propagate into a generic model instantiated inside its methods, so pydantic built the field schema from `TaskT`'s default (`Task`) and serialized against it — dropping every subclass field on the way to disk via `LocalReporter.log_sample`'s `sample.model_dump()`.

`SerializeAsAny` is the whole fix: serialize by the runtime type instead of the declared one. Nothing about validation or storage was wrong — the instance is never coerced, `sample.task` stays the real subclass with all its attributes — so this was purely a lossy dump.

That distinction is why it went unnoticed. `env.rollout(task)` and the reward function both read the live object, so a run scores correctly while its `results.jsonl` carries none of the task's declared fields (`HarborTask.task_dir`/`trial_dir`, `Tau2BenchTask.domain`/`config`, `MCPAtlasTask.gtfa_claims`, `AgentWorldModelTask.verify_code`, ...). The runs themselves stand; what was lost is post-hoc analysis, which is how the gap surfaced. Resume happened to survive it, since `completed_ids` keys on `task.id`, and `Task` allows extra fields so a re-validated task recovers them.

The test pins the reason the annotation is there, because the line does not show it — removing `SerializeAsAny` fails that test and nothing else.

## Testing

- `pytest tests/unit/` — 277 passed, 3 skipped
- `ruff check` + `ruff format --check` — clean
- `mypy src/strands_env` — clean
- Verified the new test fails with `SerializeAsAny` removed, and that no other test does