### PR TITLE
refactor(core)!: hand the sample to get_judge_agent

### DIFF
--- a/src/strands_env/core/llm_judge_reward.py
+++ b/src/strands_env/core/llm_judge_reward.py
@@ -93,25 +93,20 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
         """Get reward from judgment (structured or text)."""
         raise NotImplementedError("Subclasses must implement this method.")
 
-    async def get_judge_agent(self, system_prompt: str | None, name: str = "LLMJudge") -> Agent:
+    async def get_judge_agent(self, task: TaskT, result: RolloutResult) -> Agent:
         """Build the agent that judges one sample. Override to configure it."""
         # TODO: current model rotation is not within but across samples, amend this with a hook on AfterModelCallEvent if needed
-        return Agent(model=next(self.judge_models), system_prompt=system_prompt, tools=[], name=name)
+        return Agent(
+            model=next(self.judge_models),
+            system_prompt=await self.get_system_prompt(task, result),
+            tools=[],
+            name="LLMJudge",
+        )
 
     @override
     async def compute(self, task: TaskT, result: RolloutResult) -> RewardResult:
         def _render_error(e: Exception) -> str:
             return f"{type(e).__name__}: {e}"
-
-        # Render system prompt
-        try:
-            system_prompt = await self.get_system_prompt(task, result)
-        except Exception as e:
-            logger.error("System prompt rendering failed: %s", e)
-            return RewardResult(
-                reward=self.default_reward,
-                info={"status": "error", "error_type": "system_prompt_error", "error": _render_error(e)},
-            )
 
         # Render judge prompt
         try:
@@ -123,9 +118,18 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
                 info={"status": "error", "error_type": "judge_prompt_error", "error": _render_error(e)},
             )
 
+        # Build the judge (renders the system prompt, and for an agentic judge resolves its tools)
+        try:
+            agent = await self.get_judge_agent(task, result)
+        except Exception as e:
+            logger.error("Judge agent construction failed: %s", e)
+            return RewardResult(
+                reward=self.default_reward,
+                info={"status": "error", "error_type": "judge_agent_error", "error": _render_error(e)},
+            )
+
         # Invoke judge model (Strands' `ModelRetryStrategy` handles throttling internally)
         try:
-            agent = await self.get_judge_agent(system_prompt)
             judge_result = await agent.invoke_async(prompt, structured_output_model=self.judgment_format)
             judgment: JudgmentFormat | str = (
                 cast(JudgmentFormat, judge_result.structured_output)

--- a/tests/unit/core/test_llm_judge_reward.py
+++ b/tests/unit/core/test_llm_judge_reward.py
@@ -89,8 +89,11 @@ class TestErrorRecovery:
         assert result.reward == 0.0
         assert result.info["error_type"] == "judge_prompt_error"
 
-    async def test_system_prompt_error_returns_default_reward(self):
-        """get_system_prompt raising returns default_reward with system_prompt_error info."""
+    async def test_judge_agent_error_returns_default_reward(self):
+        """A judge that cannot be built scores default_reward with judge_agent_error info.
+
+        `get_system_prompt` is called by `get_judge_agent`, so its failures land here too.
+        """
 
         class _FailingSystemPrompt(LLMJudgeReward):
             judgment_format = None
@@ -109,7 +112,7 @@ class TestErrorRecovery:
         result = await judge.compute(task, result)
 
         assert result.reward == 0.0
-        assert result.info["error_type"] == "system_prompt_error"
+        assert result.info["error_type"] == "judge_agent_error"
 
     @patch("strands_env.core.llm_judge_reward.Agent")
     async def test_get_system_prompt_override_used(self, mock_agent_cls):
@@ -254,13 +257,21 @@ class TestHappyPath:
         mock_result.message = {"content": [{"text": "correct"}]}
         custom = MagicMock(invoke_async=AsyncMock(return_value=mock_result))
 
+        seen = {}
+
         class _CustomAgentJudge(_TextJudge):
-            async def get_judge_agent(self, system_prompt):
+            async def get_judge_agent(self, task, result):
+                seen["task"], seen["result"] = task, result
                 return custom
 
         judge = _CustomAgentJudge(judge_model=MagicMock())
-        result = await judge.compute(*_task_and_result())
+        task, rollout = _task_and_result()
+        result = await judge.compute(task, rollout)
 
         assert result.reward == 1.0
         mock_agent_cls.assert_not_called()
         custom.invoke_async.assert_awaited_once()
+        # The sample is handed to the override, so an agentic judge can bind per-sample state
+        # (e.g. request context) to its tools.
+        assert seen["task"] is task
+        assert seen["result"] is rollout


### PR DESCRIPTION
`get_judge_agent(system_prompt)` could not build an agentic judge: a judge with tools has to bind per-sample state into those tools, and the sample was not in scope. It now takes `(task, result)` and owns building the whole agent, system prompt included.

That moves `get_system_prompt` inside `get_judge_agent`, so its failures now land in a new `judge_agent_error` class that also covers whatever else the override does to construct the judge — resolving tool schemas, opening a client. Those previously surfaced as `judge_error`, indistinguishable from the model being down. Nothing filters on `error_type`; the abort path keys on `status`, which is unchanged.

## Breaking change

Anyone overriding `get_judge_agent` must update the signature: the old one took a rendered `system_prompt` and an agent `name`, and an override that ignored the system prompt now has to call `get_system_prompt` itself.

No subclass in this repo overrode it — the judge-backed benchmarks (`simpleqa-verified`, `browsecomp`, `frames`, `hle-verified`) and `Tau2BenchNLAssertionReward` only override `get_judge_prompt` / `get_system_prompt`, both unchanged. Nothing outside the base referenced `system_prompt_error`.

## Testing

- `pytest tests/unit/` — 277 passed, 3 skipped (the error-class test is renamed, not added, so the count is unchanged)
- `ruff check` + `ruff format --check` — clean
- `mypy src/strands_env` — clean
- `test_get_judge_agent_override_used` now asserts the override receives the same `task` and `result` objects, pinning the reason for the signature