### PR TITLE
fix(core): read the final response past blank trailing turns

### DIFF
--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -207,18 +207,18 @@ class RolloutResult(BaseModel):
         return self.get_final_response(raw=False)
 
     def get_final_response(self, *, raw: bool = False) -> str | None:
-        """Return text from the last assistant message, or None.
+        """Return text from the agent's last reply, or None if it did not have the last word.
 
         Args:
-            raw: If True, return the full text including <think>...</think> blocks.
-                 If False (default), strip think blocks before returning.
-
-        None when the conversation ended on a non-assistant message (e.g. a tau2
-        `user_stop` turn) — the agent did not have the last word.
+            raw: If True, keep `<think>...</think>` blocks instead of stripping them.
         """
-        if not self.messages or self.messages[-1].get("role") != "assistant":
-            return None
-        return extract_message_text(self.messages[-1], raw=raw) or None
+        for message in reversed(self.messages):
+            # Blank trailing turns: a model can report `tool_use` with no tool-use block, and the
+            # agent loop then appends an empty message and recurses past a completed answer.
+            if not extract_message_text(message, raw=True).strip():
+                continue
+            return extract_message_text(message, raw=raw) or None if message.get("role") == "assistant" else None
+        return None
 
 
 def extract_message_text(message: Message, *, raw: bool = False) -> str:

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -173,6 +173,24 @@ class TestRolloutResult:
         result = RolloutResult(messages=messages)
         assert result.final_response == "result is 4"
 
+    def test_final_response_skips_blank_trailing_turns(self):
+        # A `tool_use` stop reason with no tool-use block leaves blank turns after a full answer.
+        messages = [
+            {"role": "assistant", "content": [{"text": "the answer is 4"}]},
+            {"role": "user", "content": []},
+            {"role": "assistant", "content": [{"text": "  "}]},
+        ]
+        result = RolloutResult(messages=messages)
+        assert result.final_response == "the answer is 4"
+
+    def test_final_response_blank_turns_after_user_stop(self):
+        messages = [
+            {"role": "user", "content": [{"text": "###STOP###"}]},
+            {"role": "assistant", "content": []},
+        ]
+        result = RolloutResult(messages=messages)
+        assert result.final_response is None
+
     def test_defaults(self):
         result = RolloutResult()
         assert result.reward_result is None


### PR DESCRIPTION
## Problem

A model can report `stopReason: "tool_use"` while returning no tool-use block. The agent loop takes the tool branch regardless, appends a `content: []` message for the empty tool results and recurses — so a completed answer ends up followed by one or more blank turns.

`get_final_response` read `messages[-1]`, so those blank turns made it return `None` for a turn that had answered in full. Every judge-based reward then aborted the sample, and the evaluator drops all samples of an aborted prompt: 9 of 254 episodes lost in one Bedrock run, one of them on a 2855-character reply.

## Fix

Walk backwards past blank turns and judge the role of the first non-blank one:

```python
for message in reversed(self.messages):
    if not extract_message_text(message, raw=True).strip():
        continue
    return extract_message_text(message, raw=raw) or None if message.get("role") == "assistant" else None
return None
```

Recovers all 9 episodes. A non-assistant last turn still returns `None`, so the "agent did not have the last word" semantics tau2's `user_stop` gate relies on are unchanged.

## Tests

Two regression tests in `tests/unit/core/test_types.py`: blank trailing turns still read the completed answer, and `###STOP###` followed by an empty assistant turn still returns `None`.

313 unit tests pass; mypy, `ruff check`, and `ruff format --check` clean.