### PR TITLE
build: add dependabot, and move dev deps to a PEP 735 group

### DIFF
--- a/.claude/commands/run-integration-tests.md
+++ b/.claude/commands/run-integration-tests.md
@@ -14,7 +14,7 @@ Integration tests require a running SGLang server. Before running any commands, 
 Then proceed:
 
 1. Create a temporary venv at `/tmp/strands-env-test-venv` using `uv venv /tmp/strands-env-test-venv --python 3.12 -q`
-2. Install the package with dev dependencies: `uv pip install -e ".[dev]" --python /tmp/strands-env-test-venv/bin/python -q`
+2. Install the package with dev dependencies: `uv pip install -e . --group dev --python /tmp/strands-env-test-venv/bin/python -q`
 3. Auto-install environment-specific dependencies for tested environments: scan integration test files (`tests/integration/test_*.py`) for imports from `strands_env.environments.<name>`, then for each matched environment check if `src/strands_env/environments/<name>/requirements.txt` exists and has actual dependencies. Use `grep -v '^\s*#' <file> | grep -q '[^[:space:]]'` (POSIX-compatible, works on macOS) to skip files that only contain comments or whitespace. Install all found requirements files in a single `uv pip install` call with multiple `-r` flags.
 4. Run integration tests with the confirmed URL and tool parser: `/tmp/strands-env-test-venv/bin/python -m pytest tests/integration/ -v --tb=short --sglang-base-url=<URL> --tool-parser=<PARSER> $ARGUMENTS`
 

--- a/.claude/commands/run-unit-tests.md
+++ b/.claude/commands/run-unit-tests.md
@@ -2,7 +2,7 @@ Run unit tests in an isolated temporary venv created with uv (mimics CI).
 
 Steps:
 1. Create a temporary venv at `/tmp/strands-env-test-venv` using `uv venv /tmp/strands-env-test-venv --python 3.12 -q`
-2. Install the package with dev dependencies: `uv pip install -e ".[dev]" --python /tmp/strands-env-test-venv/bin/python -q`
+2. Install the package with dev dependencies: `uv pip install -e . --group dev --python /tmp/strands-env-test-venv/bin/python -q`
 3. Run linting: `/tmp/strands-env-test-venv/bin/ruff check src/ && /tmp/strands-env-test-venv/bin/ruff format --check src/`
 4. Run unit tests: `/tmp/strands-env-test-venv/bin/python -m pytest tests/unit/ -v --tb=short $ARGUMENTS`
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # Let a release settle before we adopt it; a yanked or broken publish is
+    # usually caught upstream within a few days.
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      # Dev tooling lands as one PR; runtime deps stay separate so a break is easy to bisect.
+      dev:
+        dependency-type: development
+        patterns: ["*"]
+    commit-message:
+      prefix: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           enable-cache: true
 
       - run: uv python install 3.12
-      - run: uv sync --python 3.12 --extra dev --extra harbor
+      - run: uv sync --python 3.12 --extra harbor
 
       # Runs the hooks themselves rather than restating each tool here, so local
       # and CI can't drift. Covers ruff, typos, zizmor, schema checks, uv-lock.
@@ -76,7 +76,7 @@ jobs:
       # Explicit install: `UV_PYTHON_DOWNLOADS: manual` permits this but stops
       # `uv sync` from fetching an interpreter on its own.
       - run: uv python install ${{ matrix.python-version }}
-      - run: uv sync --python ${{ matrix.python-version }} --extra dev --extra harbor
+      - run: uv sync --python ${{ matrix.python-version }} --extra harbor
 
       - name: pytest
         run: >-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Strands-env is a framework for building **agent environments** with Strands Agen
 
 ### Setup
 ```bash
-pip install -e ".[dev]"
+uv sync                    # installs the dev group by default
+uv sync --extra harbor     # plus an optional extra
 ```
 
 ### Linting

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For development:
 
 ```bash
 git clone https://github.com/horizon-rl/strands-env.git && cd strands-env
-pip install -e ".[dev]"
+uv sync
 ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,27 +35,28 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    # Testing
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=4.0.0",
-    "pytest-mock>=3.0.0",
-    "pytest-timeout>=2.0.0",
-    # Linting & Build
-    "pre-commit",
-    "ruff>=0.16.0",
-    "twine>=4.0.0",
-    "build>=0.10.0",
-    # Type checking
-    "mypy>=1.15.0,<2.0.0",
-]
 harbor = [
     "harbor>=0.15.0",
     "e2b==2.25.1",
 ]
 ifeval = ["lm_eval[ifeval]>=0.4.11"]
 agent-world-model = ["agent-world-model==0.1.0"]
+
+# PEP 735. Deliberately not `[project.optional-dependencies].dev`: dev tooling is
+# not a feature users can install, and it stays out of the published metadata.
+[dependency-groups]
+dev = [
+    "build>=0.10.0",
+    "mypy>=1.15.0,<2.0.0",
+    "pre-commit",
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
+    "pytest-mock>=3.0.0",
+    "pytest-timeout>=2.0.0",
+    "ruff>=0.16.0",
+    "twine>=4.0.0",
+]
 
 [tool.hatch.version]
 source = "vcs"
@@ -83,6 +84,7 @@ warn_unreachable = true
 ignore_missing_imports = true
 
 [tool.uv]
+default-groups = ["dev"]
 conflicts = [
     # agent-world-model==0.1.0 pins fastapi==0.115.12; harbor>=0.15.0 needs fastapi>=0.128.0
     [

--- a/uv.lock
+++ b/uv.lock
@@ -4263,6 +4263,15 @@ dependencies = [
 agent-world-model = [
     { name = "agent-world-model" },
 ]
+harbor = [
+    { name = "e2b" },
+    { name = "harbor" },
+]
+ifeval = [
+    { name = "lm-eval", extra = ["ifeval"] },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "build" },
     { name = "mypy" },
@@ -4275,43 +4284,40 @@ dev = [
     { name = "ruff" },
     { name = "twine" },
 ]
-harbor = [
-    { name = "e2b" },
-    { name = "harbor" },
-]
-ifeval = [
-    { name = "lm-eval", extra = ["ifeval"] },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "agent-world-model", marker = "extra == 'agent-world-model'", specifier = "==0.1.0" },
     { name = "aiolimiter", specifier = ">=1.1.0" },
-    { name = "build", marker = "extra == 'dev'", specifier = ">=0.10.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "datasets" },
     { name = "e2b", marker = "extra == 'harbor'", specifier = "==2.25.1" },
     { name = "harbor", marker = "extra == 'harbor'", specifier = ">=0.15.0" },
     { name = "lm-eval", extras = ["ifeval"], marker = "extra == 'ifeval'", specifier = ">=0.4.11" },
     { name = "math-verify", specifier = ">=0.8.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0,<2.0.0" },
     { name = "openai" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "python-dotenv" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.0" },
     { name = "strands-agents", extras = ["openai"], specifier = ">=1.46.0" },
     { name = "strands-agents-tools", specifier = ">=0.2.0" },
     { name = "strands-sglang", specifier = ">=0.6.0" },
     { name = "tiktoken", specifier = ">=0.5.0" },
     { name = "tqdm", specifier = ">=4.0.0" },
-    { name = "twine", marker = "extra == 'dev'", specifier = ">=4.0.0" },
 ]
-provides-extras = ["agent-world-model", "dev", "harbor", "ifeval"]
+provides-extras = ["agent-world-model", "harbor", "ifeval"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "build", specifier = ">=0.10.0" },
+    { name = "mypy", specifier = ">=1.15.0,<2.0.0" },
+    { name = "pre-commit" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-mock", specifier = ">=3.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.0.0" },
+    { name = "ruff", specifier = ">=0.16.0" },
+    { name = "twine", specifier = ">=4.0.0" },
+]
 
 [[package]]
 name = "strands-sglang"


### PR DESCRIPTION
Follow-up to #217, which SHA-pinned every action reference. That also froze them: pinned actions never move again, security patches included, unless something bumps them. So dependabot is a requirement now, not a nicety.

## dependabot

Weekly, both ecosystems (github-actions and uv), with a 7-day cooldown so a yanked or broken release gets caught upstream before we adopt it. Dev tooling groups into a single PR; runtime dependencies stay separate so a break is easy to bisect.

## Why dev deps had to move

Dependabot's dev grouping keys off dependencies actually being *declared* as development ones. Ours were an extra, which reads as runtime — the group would have matched nothing.

`[project.optional-dependencies].dev` → `[dependency-groups].dev` with `default-groups = ["dev"]`. Three things fall out:

- Dependabot can group dev tooling into one PR instead of five.
- The tooling leaves published metadata. `Provides-Extra` is now just `agent-world-model`, `harbor`, `ifeval` — `pip install strands-env[dev]` previously handed users twine and build.
- `uv sync` installs it by default, so CI drops the `--extra dev` it needed.

## Verification

- Wiped `.venv`, ran `uv sync --extra harbor`, confirmed pytest / mypy / ruff / pre-commit all present
- Built the wheel and read `Provides-Extra` from its METADATA
- Ran the `/run-unit-tests` flow end to end in a fresh temp venv: 279 passed, 3 skipped

## Docs that would otherwise break

`pip install -e ".[dev]"` no longer resolves, so README, CLAUDE.md and the two test slash-commands move to `uv sync` / `uv pip install -e . --group dev`.

The `mypy<2.0` ceiling stays as-is — lifting it is its own change.