### PR TITLE
build: stop mypy waving through unstubbed dependencies

### DIFF
--- a/examples/eval/browsecomp/chat_env.py
+++ b/examples/eval/browsecomp/chat_env.py
@@ -12,7 +12,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn")
         )
         judge_models.append(
             bedrock_model_factory(

--- a/examples/eval/browsecomp/web_search_env.py
+++ b/examples/eval/browsecomp/web_search_env.py
@@ -17,7 +17,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn")
         )
         judge_models.append(
             bedrock_model_factory(

--- a/examples/eval/frames/chat_env.py
+++ b/examples/eval/frames/chat_env.py
@@ -12,7 +12,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn")
         )
         judge_models.append(
             bedrock_model_factory(

--- a/examples/eval/sealqa/chat_env.py
+++ b/examples/eval/sealqa/chat_env.py
@@ -12,7 +12,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn")
         )
         judge_models.append(
             bedrock_model_factory(

--- a/examples/eval/simpleqa_verified/chat_env.py
+++ b/examples/eval/simpleqa_verified/chat_env.py
@@ -12,7 +12,7 @@ def create_env_factory(model_config: dict, **env_config):
     judge_models = []
     for profile_name in env_config.get("judge_model_profiles", [None]):
         boto_session = get_session(
-            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn", None)
+            region_name="us-west-2", profile_name=profile_name, role_arn=env_config.get("judge_model_role_arn")
         )
         judge_models.append(
             bedrock_model_factory(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,28 @@ allow-direct-references = true
 packages = ["src/strands_env"]
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 90
+markers = [
+    "integration: requires a running SGLang server or live cloud credentials",
+]
+
+[tool.coverage.run]
+source = ["src/strands_env"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "@(abc\\.)?abstractmethod",
+    "raise NotImplementedError",
+    "@(typing\\.)?overload",
+    "class .*\\bProtocol\\):",
+]
 
 [tool.mypy]
 python_version = "3.12"
@@ -79,8 +98,20 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
 disallow_untyped_decorators = true
+no_implicit_optional = true
 warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
 warn_unreachable = true
+# A dependency without stubs is named in an override below rather than waved
+# through globally, so nothing silently degrades to Any.
+ignore_missing_imports = false
+follow_untyped_imports = true
+
+# Optional-extra and training-only dependencies that ship no stubs. mypy reports
+# unused sections, so a stale entry can't outlive its dependency.
+[[tool.mypy.overrides]]
+module = ["awm.*", "lm_eval.*", "mlflow.*", "ray.*", "tau2.*", "wandb.*", "weave.*"]
 ignore_missing_imports = true
 
 [tool.uv]
@@ -99,18 +130,35 @@ fix = true
 
 [tool.ruff.lint]
 select = [
-    "B",   # flake8-bugbear
-    "D",   # pydocstyle
-    "E",   # pycodestyle
-    "F",   # pyflakes
-    "G",   # flake8-logging-format
-    "I",   # isort
-    "LOG", # logging
-    "N",   # pep8-naming
-    "UP",  # pyupgrade
-    "W",   # pycodestyle warnings
+    "ASYNC",  # flake8-async
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "D",      # pydocstyle
+    "E",      # pycodestyle
+    "F",      # pyflakes
+    "G",      # flake8-logging-format
+    "I",      # isort
+    "LOG",    # logging
+    "N",      # pep8-naming
+    "PIE",    # flake8-pie
+    "RUF006", # unowned asyncio task — a dropped task loses a rollout silently
+    "RUF012", # mutable class attr without ClassVar
+    "RUF100", # unused noqa
+    "SIM",    # flake8-simplify
+    "TRY201", # verbose raise
+    "UP",     # pyupgrade
+    "W",      # pycodestyle warnings
 ]
-ignore = ["D107", "E501", "UP046"]
+ignore = [
+    "D107",
+    "E501",
+    "UP046",
+    "ASYNC109", # `timeout` forwards to a blocking `proc.wait()`
+    "ASYNC220", # `Popen(start_new_session=True)` builds the group `killpg` tears down
+    "PIE804",   # `extra="allow"` models need `**{...}`; keywords fail mypy
+    "SIM115",   # long-lived handle, closed in `close()`/`publish()`
+    "SIM117",   # `async with self.semaphore:` is a gate, not a second resource
+]
 
 [tool.ruff.lint.per-file-ignores]
 "!src/**/*.py" = ["D"]

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -96,7 +96,6 @@ class Environment(Generic[TaskT]):
             - Paired with `cleanup`, which tears down what `reset` sets up and must
             tolerate partially-initialized state (`reset` may fail midway).
         """
-        pass
 
     async def rollout(self, task: TaskT) -> RolloutResult:
         """Run one episode: `reset(task)`, then the agent loop, then `cleanup()` (always).
@@ -162,7 +161,6 @@ class Environment(Generic[TaskT]):
 
     async def cleanup(self) -> None:
         """Release resources. Override in subclasses."""
-        pass
 
     def get_tools(self) -> list:
         """Tools available to the agent. Override in subclasses."""

--- a/src/strands_env/environments/agent_world_model/reward.py
+++ b/src/strands_env/environments/agent_world_model/reward.py
@@ -36,7 +36,7 @@ class AgentWorldModelReward(RewardFunction[AgentWorldModelTask]):
         # blocking exec + SQLite I/O, shipped to a thread below
         def _verify() -> dict:
             namespace: dict = {"sqlite3": sqlite3, "json": json}
-            exec(task.verify_code, namespace)  # noqa: S102
+            exec(task.verify_code, namespace)
             return namespace["verify_task_completion"](
                 initial_db_path=task.initial_db_path,
                 final_db_path=str(work_db_path),

--- a/src/strands_env/environments/calculator/reward.py
+++ b/src/strands_env/environments/calculator/reward.py
@@ -67,7 +67,8 @@ class MathVerifyReward(RewardFunction):
                 parse(
                     text,
                     extraction_config=_EXTRACTION_CONFIG,
-                    parsing_timeout=None,  # Disable math-verify's timeout, use manual timeout
+                    # Annotated `int` upstream, but None is the documented way to opt out.
+                    parsing_timeout=None,  # type: ignore[arg-type]
                     raise_on_error=True,
                 )
             )

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -39,7 +39,7 @@ class HarborReward(RewardFunction["HarborTask"]):
             )
             verifier_result = await asyncio.wait_for(verifier.verify(), timeout=timeout)
             # reward.json is unvalidated upstream; loud indexing raises on a missing key, never a silent 0
-            return RewardResult(reward=float(verifier_result.rewards["reward"]), info={"status": "success"})
+            return RewardResult(reward=float(verifier_result.rewards["reward"]), info={"status": "success"})  # type: ignore[index]
         except Exception as e:
             logger.exception("Verification failed due to %s: %s", type(e).__name__, str(e))
             return RewardResult(reward=0.0, info={"status": "error", "message": str(e)})

--- a/src/strands_env/environments/web_search/env.py
+++ b/src/strands_env/environments/web_search/env.py
@@ -58,7 +58,7 @@ class WebSearchEnv(Environment):
         self.search_toolkit = WebSearchToolkit(
             timeout=int(self.config.get("search_timeout", 10)),
             concurrency=search_concurrency,
-            blocked_domains=self.config.get("blocked_domains"),  # type: ignore[arg-type]
+            blocked_domains=self.config.get("blocked_domains"),
             api_provider=self.config.get("search_provider", "serper"),
         )
         self.search_tool = self.search_toolkit.search

--- a/src/strands_env/eval/benchmarks/browsecomp.py
+++ b/src/strands_env/eval/benchmarks/browsecomp.py
@@ -124,7 +124,7 @@ class BrowseCompEvaluator(Evaluator):
     @classmethod
     def derive_key(cls, password: str, length: int) -> bytes:
         """Derive a fixed-length key from the password using SHA256."""
-        digest = hashlib.sha256(password.encode()).digest()  # noqa: S324 — not for security; replicates OpenAI simple-evals XOR obfuscation
+        digest = hashlib.sha256(password.encode()).digest()
         return digest * (length // len(digest)) + digest[: length % len(digest)]
 
     @classmethod

--- a/src/strands_env/eval/benchmarks/ifeval.py
+++ b/src/strands_env/eval/benchmarks/ifeval.py
@@ -8,6 +8,7 @@ from typing import Any, override
 
 from datasets import load_dataset
 from lm_eval.tasks.ifeval.utils import process_results
+from pydantic import Field
 
 from strands_env.core import Task
 from strands_env.core.types import RewardFunction, RewardResult, RolloutResult
@@ -30,8 +31,8 @@ class IFEvalTask(Task):
     """`Task` carrying the IFEval row fields the grader needs."""
 
     key: int = 0
-    instruction_id_list: list[Any] = []
-    ifeval_kwargs: list[Any] = []
+    instruction_id_list: list[Any] = Field(default_factory=list)
+    ifeval_kwargs: list[Any] = Field(default_factory=list)
 
 
 class IFEvalReward(RewardFunction):

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -52,7 +52,8 @@ class TerminalBenchEvaluator(Evaluator[HarborTask]):
             trial_dir=self.output_path.parent / task_dir.name,
             system_prompt=self.system_prompt_path.read_text().strip() if self.system_prompt_path else None,
         )
-        task.task_env_config.memory_mb *= 2
+        if task.task_env_config.memory_mb is not None:
+            task.task_env_config.memory_mb *= 2
         return task
 
     @override

--- a/src/strands_env/utils/slime_logger.py
+++ b/src/strands_env/utils/slime_logger.py
@@ -246,6 +246,6 @@ class RolloutLogger:
         if not rows:
             return
 
-        mlflow.log_dict(rows, f"rollout_samples/step_{step:05d}.json")  # type: ignore[arg-type]
+        mlflow.log_dict(rows, f"rollout_samples/step_{step:05d}.json")
 
         logger.info("Logged %d samples to MLflow (rollout %d, step %d)", len(rows), rollout_id, step)

--- a/tests/integration/test_harbor.py
+++ b/tests/integration/test_harbor.py
@@ -36,7 +36,7 @@ def docker_available():
     if not shutil.which("docker"):
         pytest.skip("docker CLI not found")
     try:
-        result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)  # noqa: S603, S607
+        result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
         if result.returncode != 0:
             pytest.skip("Docker daemon not running")
     except subprocess.TimeoutExpired:

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -60,7 +60,7 @@ class TestBedrockModelFactory:
             model_id="test",
             boto_session=MagicMock(spec=boto3.Session),
         )
-        assert DEFAULT_SAMPLING_PARAMS == original
+        assert original == DEFAULT_SAMPLING_PARAMS
 
     @patch("strands_env.core.models.BedrockModel")
     def test_shared_client_across_instances(self, mock_bedrock_cls):
@@ -118,7 +118,7 @@ class TestBedrockMantleModelFactory:
         _, patch_model = self._patch_model()
         with patch_model:
             bedrock_mantle_model_factory(model_id="openai.gpt-5.4-2026-03-05")
-        assert DEFAULT_SAMPLING_PARAMS == original
+        assert original == DEFAULT_SAMPLING_PARAMS
 
     def test_build_model_factory_requires_model_id(self):
         with pytest.raises(ValueError, match="bedrock-mantle backend requires"):
@@ -147,4 +147,4 @@ class TestOpenAIModelFactory:
     def test_does_not_mutate_default_params(self, mock_openai_cls):
         original = dict(DEFAULT_SAMPLING_PARAMS)
         openai_model_factory(model_id="gpt-4o")
-        assert DEFAULT_SAMPLING_PARAMS == original
+        assert original == DEFAULT_SAMPLING_PARAMS

--- a/tests/unit/environments/harbor/test_e2b.py
+++ b/tests/unit/environments/harbor/test_e2b.py
@@ -20,10 +20,10 @@ import pytest
 # convention in tests/integration/test_harbor.py).
 pytest.importorskip("harbor", reason="harbor>=0.13.2 required for the e2b backend adapter")
 
-from e2b.exceptions import AuthenticationException  # noqa: E402
+from e2b.exceptions import AuthenticationException
 
-from strands_env.environments.harbor import e2b  # noqa: E402
-from strands_env.environments.harbor.e2b import PrebakedE2BEnvironment  # noqa: E402
+from strands_env.environments.harbor import e2b
+from strands_env.environments.harbor.e2b import PrebakedE2BEnvironment
 
 #: `validate_api_key` is a module-level function; bind it for readable tests.
 validate_api_key = e2b.validate_api_key

--- a/tests/unit/environments/harbor/test_env.py
+++ b/tests/unit/environments/harbor/test_env.py
@@ -17,9 +17,9 @@ from pydantic import BaseModel
 
 pytest.importorskip("harbor", reason="harbor>=0.13.2 required for HarborConfig")
 
-from strands_env.environments.harbor import env as harbor_env  # noqa: E402
-from strands_env.environments.harbor.env import HarborConfig, HarborEnv  # noqa: E402
-from strands_env.environments.harbor.task import HarborTask  # noqa: E402
+from strands_env.environments.harbor import env as harbor_env
+from strands_env.environments.harbor.env import HarborConfig, HarborEnv
+from strands_env.environments.harbor.task import HarborTask
 
 
 def test_harbor_config_type_hints_resolve():

--- a/tests/unit/eval/test_terminal_bench.py
+++ b/tests/unit/eval/test_terminal_bench.py
@@ -8,8 +8,8 @@ import pytest
 
 pytest.importorskip("harbor", reason="harbor>=0.13.2 required to import the terminal_bench benchmark module")
 
-from strands_env.eval import get_benchmark, list_benchmarks  # noqa: E402
-from strands_env.eval.benchmarks.terminal_bench import TerminalBench21Evaluator  # noqa: E402
+from strands_env.eval import get_benchmark, list_benchmarks
+from strands_env.eval.benchmarks.terminal_bench import TerminalBench21Evaluator
 
 
 def test_terminal_bench_variants_registered():
@@ -44,3 +44,44 @@ def test_terminal_bench_21_scans_tasks_subdir(tmp_path: Path, monkeypatch: pytes
     monkeypatch.setattr(evaluator, "_load_single_task", lambda task_dir: task_dir.name)
 
     assert evaluator.load_dataset() == ["alpha", "beta"]
+
+
+def _write_task_bundle(task_dir: Path, *, memory_mb: int | None) -> None:
+    task_dir.mkdir(parents=True)
+    (task_dir / "instruction.md").write_text("do the thing\n")
+    (task_dir / "tests").mkdir()
+    (task_dir / "tests" / "test.sh").write_text("exit 0\n")
+    memory_line = f"memory_mb = {memory_mb}\n" if memory_mb is not None else ""
+    (task_dir / "task.toml").write_text(
+        'schema_version = "1.1"\n'
+        "artifacts = []\n"
+        "\n"
+        "[task]\n"
+        f'name = "fixture/{task_dir.name}"\n'
+        'description = "fixture"\n'
+        "\n"
+        "[verifier]\n"
+        "timeout_sec = 60.0\n"
+        "\n"
+        "[environment]\n"
+        'docker_image = "alpine:3"\n'
+        f"{memory_line}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("declared", "expected"),
+    [(2048, 4096), (None, None)],
+    ids=["doubles_when_declared", "left_alone_when_absent"],
+)
+def test_memory_mb_doubling_tolerates_an_absent_value(
+    tmp_path: Path, declared: int | None, expected: int | None
+) -> None:
+    """`memory_mb` is Optional upstream, so doubling it has to survive a task that omits it."""
+    task_dir = tmp_path / "alpha"
+    _write_task_bundle(task_dir, memory_mb=declared)
+    evaluator = TerminalBench21Evaluator(env_factory=lambda: None, output_path=tmp_path / "out" / "results.jsonl")
+
+    task = evaluator._load_single_task(task_dir)
+
+    assert task.task_env_config.memory_mb == expected


### PR DESCRIPTION
## The hole

`ignore_missing_imports = true` applied to *every* import, so harbor, ray, tau2, lm_eval, awm, wandb, weave and mlflow all resolved to `Any` — and so did anything reached through them. Flipped to `false` with `follow_untyped_imports = true` plus one override naming the stubless dependencies. mypy reports unused override sections, so an entry can't outlive its dependency.

## The bug it found

`terminal_bench` doubled `task_env_config.memory_mb` unconditionally:

```python
task.task_env_config.memory_mb *= 2
```

harbor declares it `memory_mb: int | None = None`. Every task in the current dataset (89/89) sets it, so nothing has failed yet — but a task that omits it raises `TypeError` inside `load_dataset`, taking down the **whole run** rather than one sample.

Fixed, with a parametrized test that builds a real on-disk Harbor bundle (task.toml + instruction.md + tests/test.sh) both with and without `memory_mb`. Verified it catches the bug by reverting the fix:

```
E   TypeError: unsupported operand type(s) for *=: 'NoneType' and 'int'
FAILED ...test_memory_mb_doubling_tolerates_an_absent_value[left_alone_when_absent]
```

## Not our bugs

Two findings are upstream annotations being wrong, so both got narrow ignores rather than rewrites:

- `VerifierResult.rewards` is `dict | None`, and indexing it is the *intended* loud failure on a malformed reward.json — the existing comment says so.
- math-verify types `parsing_timeout` as `int` while its own docstring documents `None` as the way to opt out (which we need, since its signal-based timeout doesn't work off the main thread).

`warn_no_return` also retired two `type: ignore`s that `follow_untyped_imports` made unnecessary.

## What I left off

`warn_return_any` — all 16 hits are `Any` crossing an untyped boundary (`json.load`, `getattr`, `re.findall`, boto3, pydantic's `model_dump_json`) into an already-correct signature. Casting each one buys no checking.

`filterwarnings = ["error"]` — 20 tests leak the LocalReporter file handle and GC's ResourceWarning would fail them. Fixing those is its own change.

## ruff

Added ASYNC, C4, PIE, SIM, TRY201, RUF006/012/100. Five rules ignored with the reason inline, each wanting a rewrite that's wrong here — including **PIE804**, which would break the `**{...}` spelling that `extra="allow"` pydantic models need to pass mypy (verified: keywords give `Unexpected keyword argument`).

**RUF012** was a genuine miss — the IFEval task fields are pydantic fields, so `Field(default_factory=list)` is correct. **RUF100** removed three dead `noqa`s for rule families we don't enable; the one carrying a real rationale (SHA256 not-for-security in browsecomp) has that same note in the section header two lines above.

pytest gains `testpaths`, `python_files` and the `integration` marker it already uses; coverage settings move from CI flags into the file.

315 unit tests pass (313 + the 2 new).