### PR TITLE
ci: rebuild publish.yml, and fix the stale CI badge

### DIFF
--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -41,7 +41,7 @@ Present the full release notes in the body format below and ask the user to conf
 ### Bug Fixes
 - Brief description of fix
 
-**Full Changelog**: https://github.com/horizon-rl/strands-env/compare/<last_tag>...v<new_version>
+**Full Changelog**: https://github.com/strands-rl/strands-env/compare/<last_tag>...v<new_version>
 ```
 
 ### 4. Create the GitHub release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,55 +1,69 @@
-name: Publish to PyPI
+name: Publish
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Where to publish
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
+    name: build sdist & wheel
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Version is derived from git tags; shallow clones can't see them.
+          fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      # Caching is off by choice, not omission: setup-uv caches by default, and a
+      # poisoned cache entry would land inside a published artifact.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: "3.12"
+          enable-cache: false
 
-      - name: Install build tools
-        run: pip install build twine
+      - run: uv build
 
-      - name: Build package
-        run: python -m build
+      - name: Check metadata renders on PyPI
+        run: uvx twine check --strict dist/*
 
-      - name: Check package
-        run: twine check dist/*
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
 
-  publish-pypi:
+  publish:
+    name: publish to ${{ github.event_name == 'release' && 'pypi' || inputs.target }}
     needs: build
     runs-on: ubuntu-latest
-    environment: pypi
+    # Environment gates the release; add required reviewers there if wanted.
+    environment:
+      name: ${{ github.event_name == 'release' && 'pypi' || inputs.target }}
+      url: https://pypi.org/p/strands-env
     permissions:
-      id-token: write  # Required for trusted publishing
-
+      # Trusted publishing (OIDC) + PEP 740 attestations — no API tokens stored.
+      id-token: write
+      attestations: write
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
-      - name: Publish to PyPI
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        # Uses trusted publishing (OIDC) - no API token needed
-        # Configure at: https://pypi.org/manage/project/strands-env/settings/publishing/
+        with:
+          attestations: true
+          repository-url: >-
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+                && 'https://test.pypi.org/legacy/' || '' }}

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Awesome Strands Agents](https://img.shields.io/badge/Awesome-Strands%20Agents-00FF77?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjkwIiBoZWlnaHQ9IjQ2MyIgdmlld0JveD0iMCAwIDI5MCA0NjMiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik05Ny4yOTAyIDUyLjc4ODRDODUuMDY3NCA0OS4xNjY3IDcyLjIyMzQgNTYuMTM4OSA2OC42MDE3IDY4LjM2MTZDNjQuOTgwMSA4MC41ODQzIDcxLjk1MjQgOTMuNDI4MyA4NC4xNzQ5IDk3LjA1MDFMMjM1LjExNyAxMzkuNzc1QzI0NS4yMjMgMTQyLjc2OSAyNDYuMzU3IDE1Ni42MjggMjM2Ljg3NCAxNjEuMjI2TDMyLjU0NiAyNjAuMjkxQy0xNC45NDM5IDI4My4zMTYgLTkuMTYxMDcgMzUyLjc0IDQxLjQ4MzUgMzY3LjU5MUwxODkuNTUxIDQxMS4wMDlMMTkwLjEyNSA0MTEuMTY5QzIwMi4xODMgNDE0LjM3NiAyMTQuNjY1IDQwNy4zOTYgMjE4LjE5NiAzOTUuMzU1QzIyMS43ODQgMzgzLjEyMiAyMTQuNzc0IDM3MC4yOTYgMjAyLjU0MSAzNjYuNzA5TDU0LjQ3MzggMzIzLjI5MUM0NC4zNDQ3IDMyMC4zMjEgNDMuMTg3OSAzMDYuNDM2IDUyLjY4NTcgMzAxLjgzMUwyNTcuMDE0IDIwMi43NjZDMzA0LjQzMiAxNzkuNzc2IDI5OC43NTggMTEwLjQ4MyAyNDguMjMzIDk1LjUxMkw5Ny4yOTAyIDUyLjc4ODRaIiBmaWxsPSIjRkZGRkZGIi8+CjxwYXRoIGQ9Ik0yNTkuMTQ3IDAuOTgxODEyQzI3MS4zODkgLTIuNTc0OTggMjg0LjE5NyA0LjQ2NTcxIDI4Ny43NTQgMTYuNzA3NEMyOTEuMzExIDI4Ljk0OTIgMjg0LjI3IDQxLjc1NyAyNzIuMDI4IDQ1LjMxMzhMNzEuMTcyNyAxMDMuNjcxQzQwLjcxNDIgMTEyLjUyMSAzNy4xOTc2IDE1NC4yNjIgNjUuNzQ1OSAxNjguMDgzTDI0MS4zNDMgMjUzLjA5M0MzMDcuODcyIDI4NS4zMDIgMjk5Ljc5NCAzODIuNTQ2IDIyOC44NjIgNDAzLjMzNkwzMC40MDQxIDQ2MS41MDJDMTguMTcwNyA0NjUuMDg4IDUuMzQ3MDggNDU4LjA3OCAxLjc2MTUzIDQ0NS44NDRDLTEuODIzOSA0MzMuNjExIDUuMTg2MzcgNDIwLjc4NyAxNy40MTk3IDQxNy4yMDJMMjE1Ljg3OCAzNTkuMDM1QzI0Ni4yNzcgMzUwLjEyNSAyNDkuNzM5IDMwOC40NDkgMjIxLjIyNiAyOTQuNjQ1TDQ1LjYyOTcgMjA5LjYzNUMtMjAuOTgzNCAxNzcuMzg2IC0xMi43NzcyIDc5Ljk4OTMgNTguMjkyOCA1OS4zNDAyTDI1OS4xNDcgMC45ODE4MTJaIiBmaWxsPSIjRkZGRkZGIi8+Cjwvc3ZnPgo=&logoColor=white)](https://github.com/cagataycali/awesome-strands-agents)
 
-[![CI](https://github.com/horizon-rl/strands-env/actions/workflows/test.yml/badge.svg)](https://github.com/horizon-rl/strands-env/actions/workflows/test.yml)
+[![CI](https://github.com/strands-rl/strands-env/actions/workflows/ci.yml/badge.svg)](https://github.com/strands-rl/strands-env/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/strands-env.svg)](https://pypi.org/project/strands-env/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/horizon-rl/strands-env)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/strands-rl/strands-env)
 
 A framework for building agent environments for RL training and evaluation with Strands Agents.
 
@@ -14,7 +14,7 @@ A framework for building agent environments for RL training and evaluation with 
 An **agent environment** takes a task and runs the agent to completion over multiple turns, producing a **rollout result** — the trajectory, reward, and termination reason for that task. With `strands-env`, you can:
 
 - **Define Environments** — Subclass `Environment`, add `@tool` functions, plug in `RewardFunction`; typed `Task` subclasses carry per-sample fields
-- **RL Training** — Token-level trajectories (TITO) for on-policy training with [strands-sglang](https://github.com/horizon-rl/strands-sglang)
+- **RL Training** — Token-level trajectories (TITO) for on-policy training with [strands-sglang](https://github.com/strands-rl/strands-sglang)
 - **Benchmarking** — CLI and `Evaluator` with checkpointing, resume, and custom metrics
 
 ## Install
@@ -26,7 +26,7 @@ pip install strands-env
 For development:
 
 ```bash
-git clone https://github.com/horizon-rl/strands-env.git && cd strands-env
+git clone https://github.com/strands-rl/strands-env.git && cd strands-env
 uv sync
 ```
 

--- a/examples/slime/retool/README.md
+++ b/examples/slime/retool/README.md
@@ -17,7 +17,7 @@ slime-based RL training for math problem solving using `AgentCoreCodeEnv` (based
 
 2. **Install strands-env**:
    ```bash
-   git clone https://github.com/horizon-rl/strands-env.git
+   git clone https://github.com/strands-rl/strands-env.git
    cd strands-env
    pip install -e .
    ```


### PR DESCRIPTION
## The badge was dead

Renaming the workflow in #217 left README pointing at `test.yml`, which no longer exists — the CI badge rendered as nothing. Badge and link both move to `ci.yml`.

While in there, `horizon-rl` → `strands-rl` in the four places it was still written: two README links, the retool example, and the release-notes template in `create-release.md` — that last one would otherwise stamp the old org into every release note.

## publish.yml off pip

- **`uv build`** replaces `pip install build twine` + `python -m build`, and `uvx twine check --strict` catches metadata that won't render on PyPI.
- **`fetch-depth: 0`** — hatch-vcs derives the version from git tags, and a shallow clone can't see them. Publishing from a shallow clone produces something like `0.0.1.dev1`, which is unrecoverable: PyPI won't accept a second upload of the same filename.
- **`attestations: true`** with the `attestations: write` permission, so releases carry PEP 740 provenance alongside the OIDC trusted publishing we already had.
- **`enable-cache: false`** on setup-uv. It caches by default, and a poisoned cache entry would land inside a published artifact.
- **`permissions: {}`** at top level with each job opting into what it needs.

## testpypi target

`workflow_dispatch` gains a `testpypi` / `pypi` choice so the pipeline can be exercised without burning a version number.

Using it needs two one-time setup steps outside this PR — a `testpypi` GitHub environment, and a TestPyPI trusted publisher for the repo. The release path is unaffected until then; `on: release` still resolves to the existing `pypi` environment.

## Verified

- `check-github-workflows` (schema) and `zizmor` (supply chain) both pass
- Full hook suite green after rebasing onto #224