### PR TITLE
test: make warnings fatal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ python_files = ["test_*.py"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 90
+filterwarnings = ["error"]
 markers = [
     "integration: requires a running SGLang server or live cloud credentials",
 ]

--- a/tests/unit/eval/conftest.py
+++ b/tests/unit/eval/conftest.py
@@ -1,0 +1,34 @@
+"""Fixtures shared by the eval unit tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from strands_env.eval import LocalReporter
+
+
+@pytest.fixture(autouse=True)
+def close_local_reporters(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Close the file handle of every `LocalReporter` built during a test.
+
+    `publish()` closes it in the real lifecycle; these tests assert on the file
+    instead of running that far, and `Evaluator` builds its reporter internally so
+    there is nothing for the test to close. Left open, GC raises ResourceWarning —
+    which `filterwarnings = ["error"]` turns into a failure pinned on whichever test
+    the collector happens to interrupt.
+    """
+    built: list[LocalReporter] = []
+    original_init = LocalReporter.__init__
+
+    def recording_init(self: LocalReporter, *args: object, **kwargs: object) -> None:
+        original_init(self, *args, **kwargs)  # type: ignore[arg-type]
+        built.append(self)
+
+    monkeypatch.setattr(LocalReporter, "__init__", recording_init)
+    yield
+    for reporter in built:
+        if reporter._fh is not None:
+            reporter._fh.close()
+            reporter._fh = None


### PR DESCRIPTION
A dependency deprecation currently scrolls past in the pytest output. With dependabot now opening major-version bumps — `datasets` 5.0.1 is waiting in #222 — the suite should fail on one instead of printing it.

Verified it bites, by raising a `DeprecationWarning` in a throwaway test:

```
E   DeprecationWarning: pretend a dependency deprecated something
FAILED tests/unit/eval/test_registry.py::test_TEMP_deprecation_is_fatal
```

## Why 20 tests had to stop leaking first

`LocalReporter` holds its `results.jsonl` handle open and closes it in `publish()`. These tests assert on the file rather than running that far, and `Evaluator` builds its reporter internally — so there's no handle for the test to reach even if it wanted to. GC then raises `ResourceWarning`, which `filterwarnings = ["error"]` turns into a failure.

The failures land on whichever test the collector happens to interrupt, not the one that leaked. That's why one of them was in `test_utils.py::TestGetSession` — which passes in isolation and has no reporter anywhere near it.

An autouse fixture in `tests/unit/eval/conftest.py` closes what each test opened.

## Nothing in src changes

The production path (`cli.py`) does call `publish()`, so the handle is closed in a real eval run. This is test bookkeeping, not a leak in the reporter.

315 unit tests pass; full hook suite green.