### PR TITLE
build: bound the sdist, and add the project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
     "aiolimiter>=1.1.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/strands-rl/strands-env"
+Repository = "https://github.com/strands-rl/strands-env"
+Issues = "https://github.com/strands-rl/strands-env/issues"
+
 [project.optional-dependencies]
 harbor = [
     "harbor>=0.15.0",
@@ -66,6 +71,11 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/strands_env"]
+
+# An allowlist, not an exclude list: hatchling reads the filesystem rather than git,
+# so anything untracked but present (.local/, scratch eval runs) would otherwise ship.
+[tool.hatch.build.targets.sdist]
+include = ["src", "tests", "examples", "README.md", "LICENSE", "CITATION.cff"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -166,3 +176,6 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.isort]
+known-first-party = ["strands_env"]


### PR DESCRIPTION
## The sdist was unbounded

No `[tool.hatch.build.targets.sdist]`, so hatchling fell back to shipping most of the repo. Locally that's a **3.3 MB** archive containing `.claude/`, `.devin/`, `.github/`, and `.local/` — the last of which holds an **e2b API key** plus a few finished eval runs.

hatchling reads the filesystem, not git, so `.gitignore` doesn't hold it back.

The published 0.6.7 sdist *is* clean — CI builds from a fresh checkout where `.local/` doesn't exist. I downloaded it and confirmed. But a `uv build` on a developer machine followed by a manual upload would have published that key, and nothing was stopping it.

An explicit include list closes the hole:

```
before: 3.3 MB — .claude .devin .github .local docs examples glm45_air_tokenizer src tests uv.lock ...
after:  148 KB — src tests examples README.md LICENSE CITATION.cff
```

An allowlist rather than an exclude list, because the failure mode is "something new appears in the working tree and silently ships".

### Verified

- Built both artifacts, listed the tarball
- Installed the sdist into a clean venv (`uv pip install --no-deps <sdist>`)
- Ran the same `uvx twine check --strict` that `publish.yml` runs — both PASSED
- Wheel unchanged: still just `strands_env/` + dist-info

## Two smaller gaps

**`[project.urls]`** — PyPI had no Homepage/Repository/Issues links to render. Now in the metadata as `Project-URL:` entries.

**`known-first-party = ["strands_env"]`** for isort — reorders nothing today (hooks pass with no diff); it keeps `strands_env` sorted after third-party once someone adds a module whose name sorts ambiguously.