### PR TITLE
style: drop module docstrings, and write down the rest of the style rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,11 +129,19 @@ Each environment is a package: `env.py` holds the `Environment` subclass, plus d
 - Pydocstyle with Google convention, formatting and content only (`D2`/`D4`, enforced in `src/`)
 - Mypy with near-strict settings (see `pyproject.toml` for full config)
 - Use lazy `%` formatting for logging (not f-strings)
-- Use single backticks `` `xx` `` in docstrings (not Sphinx-style double backticks)
+- Single backticks around identifiers and endpoints — `` `input_ids` ``, not Sphinx-style double backticks. Applies to docstrings, comments, and Markdown.
 - Conventional commits (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert)
 - Python 3.12+ required (CI tests 3.12 and 3.13)
 - asyncio_mode = "auto" for pytest-asyncio
 - Async-first: all Environment methods that interact with Agent are async
+
+### Files
+
+No licence or copyright headers — `LICENSE` at the repo root is the whole story.
+
+No module or package docstrings. A file starts at its first import or definition;
+`D100` and `D104` are unselected for that reason. The path already says what
+`harbor/task.py` holds.
 
 ### Docstring Style
 
@@ -145,15 +153,73 @@ to the ones that are there.
 That licence is for the plain cases only. Everything below is a place where the
 signature genuinely doesn't carry the fact, so it stays documented:
 
-- **Module**: one line, what the file contains ("The per-sample input type for `XxxEnv`."). A paragraph only for load-bearing context (e.g. an import-time trap).
 - **Class**: one-line summary; facts the signature can't show (lifecycle, resource ownership) go in `Notes:`.
 - **Config TypedDicts**: first line "Serializable configuration for `XxxEnv`."; each field gets an inline comment with its default (`# seconds per MCP tool call (default 60)`) — the default otherwise hides in a distant `.get()`.
 - **`__init__`**: NO docstring when parameters are self-evident — its presence is the signal that something needed saying. Write a full `Args:` section only when parameters carry semantics: ownership, sharing, fallback behavior.
 - **Methods**: one imperative line saying what the signature can't; overrides state what this implementation does differently.
-- **Task classes**: module line is the uniform locator ("The per-sample input type for `XxxEnv`."); the class line says what one sample IS ("One Harbor-format task bundle on disk, plus where this trial writes its outputs."). `Field(description=...)` per field, carrying semantics, not restating types. Tasks may own data-derived views of their fields (path wrappers, world materialization) but never scoring behavior — that lives on `RewardFunction`.
+- **Task classes**: the class line says what one sample IS ("One Harbor-format task bundle on disk, plus where this trial writes its outputs."). `Field(description=...)` per field, carrying semantics, not restating types. Tasks may own data-derived views of their fields (path wrappers, world materialization) but never scoring behavior — that lives on `RewardFunction`.
 - **Env classes**: domain-first summaries ("Web-search environment with ...", "Code sandbox environment using ..."), matching the family pattern.
 - **`@tool` methods**: their docstrings are agent-facing tool specs — exempt from human-prose edits.
 - **Mechanics**: single backticks, no Sphinx roles, no design-session jargon ("operator-authored" → plain reader terms); comments state constraints, not narration. When editing docstrings, fix the disease and keep the healthy tissue — don't rewrite working prose for taste.
+
+### Comments
+
+One sentence. Longer only when the reasoning genuinely doesn't compress.
+
+Comment the *why*, on the line it explains. Design rationale that needs paragraphs
+belongs in the commit message, attached to the change rather than to the code forever.
+
+### Private helpers
+
+Extract a helper because the logic has a *name*, not because it repeats. Repetition is
+usually better removed with a parameter or a loop; a helper earns its place by naming a
+concept. Eight to fifteen lines is the size at which naming something starts to pay.
+
+- **Under four lines: look for a reason to keep it.** The indirection usually costs more
+  than it saves. It survives when the body carries a rule a caller would otherwise repeat
+  — `_get_session` is three lines because "reopen if the session closed" belongs in one
+  place, not at five call sites.
+- **Called once: the name has to say something concrete.** Single-use helpers are normal,
+  so call count is not the test — nameability is. If the best name available is `_add` or
+  `_process`, there is no concept to extract.
+- **Private share is a smell, not a limit.** A high share is fine when each name is a
+  domain concept: `Tau2BenchReward` is 4/6 private because tau2 defines four sub-rewards
+  (`_db_reward`, `_action_reward`, ...) and the class exists to combine them. It is a
+  problem when the names are stages of one procedure that was sliced up.
+
+When a helper does survive, define it before its callers so reading top to bottom never
+requires jumping ahead.
+
+### Module-level private functions
+
+**Default is zero per file** — currently three in `src/`, and each has an argument for
+why it belongs to no class. Adding one means making that argument. A module-level
+`_helper` has no owner, which is why these accumulate: anyone can add one and nothing
+says what it pairs with.
+
+Where they usually belong instead:
+
+- Used by one class → make it a method on that class.
+- Used once inside one function → inline it, or nest it in that function.
+- A genuinely general pure function used from several places → it is probably public, or
+  it belongs in `utils/`.
+
+Module-level private *constants* (`_EXTRACTION_CONFIG = (...)`) are exempt — constants
+belong at module scope.
+
+## Tests
+
+Group into a class named for the unit under test (`TestRolloutResult`,
+`TestTerminationReason`), with the methods naming only the scenario — don't repeat the
+class's subject in both. Grouped method names read short, three or four words.
+
+Reach for a class when there are three or more scenarios; below that a module-level
+function carries the context on its own.
+
+Docstrings on tests are optional and most are better off without one — the name is the
+documentation. Write one when the *reason* the case exists isn't obvious from the name
+(a regression whose trigger needs naming, a fidelity claim against upstream behaviour).
+If a single assertion needs justification, a one-line comment above it beats a docstring.
 
 ## Class Attribute Conventions
 

--- a/examples/bedrock_judge_demo.py
+++ b/examples/bedrock_judge_demo.py
@@ -1,15 +1,3 @@
-"""LLM-as-judge reward demo using Bedrock.
-
-This example demonstrates:
-- Creating a custom LLMJudgeRewardFunction subclass
-- Using structured output for judgment
-- Evaluating responses with an LLM judge
-
-Usage:
-    python examples/bedrock_judge_demo.py
-    python examples/bedrock_judge_demo.py --model-id us.anthropic.claude-sonnet-4-20250514-v1:0
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/examples/eval/aime/agentcore_code_env.py
+++ b/examples/eval/aime/agentcore_code_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for math reasoning evaluation with `AgentCoreCodeEnv`."""
-
 from strands_env.core.models import build_model_factory
 from strands_env.environments.agentcore_code import AgentCoreCodeEnv
 from strands_env.environments.agentcore_code.quotas import CodeInterpreterQuotas

--- a/examples/eval/aime/chat_env.py
+++ b/examples/eval/aime/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for math reasoning evaluation with `Environment`."""
-
 from strands_env.core import Environment
 from strands_env.core.models import build_model_factory
 from strands_env.environments.math.reward import MathVerifyReward

--- a/examples/eval/browsecomp/chat_env.py
+++ b/examples/eval/browsecomp/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for BrowseComp evaluation with a chat-only environment (no tools)."""
-
 from strands_env.core import Environment
 from strands_env.core.models import bedrock_model_factory, build_model_factory
 from strands_env.eval.benchmarks.browsecomp import BrowseCompReward

--- a/examples/eval/browsecomp/web_search_env.py
+++ b/examples/eval/browsecomp/web_search_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for BrowseComp evaluation with Serper search + Jina-based web scraping."""
-
 import asyncio
 
 from strands_env.core.models import bedrock_model_factory, build_model_factory

--- a/examples/eval/frames/chat_env.py
+++ b/examples/eval/frames/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for FRAMES evaluation with a chat-only environment (no tools)."""
-
 from strands_env.core import Environment
 from strands_env.core.models import bedrock_model_factory, build_model_factory
 from strands_env.eval.benchmarks.frames import FramesReward

--- a/examples/eval/gpqa/agentcore_code_env.py
+++ b/examples/eval/gpqa/agentcore_code_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for GPQA evaluation with AgentCoreCodeEnv."""
-
 from strands_env.core.models import build_model_factory
 from strands_env.environments.agentcore_code import AgentCoreCodeEnv
 from strands_env.environments.agentcore_code.quotas import CodeInterpreterQuotas

--- a/examples/eval/gpqa/chat_env.py
+++ b/examples/eval/gpqa/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for GPQA evaluation with a chat-only environment (no tools)."""
-
 from strands_env.core import Environment
 from strands_env.core.models import build_model_factory
 from strands_env.eval.benchmarks.gpqa import GPQAReward

--- a/examples/eval/hle_verified/chat_env.py
+++ b/examples/eval/hle_verified/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for HLE-Verified evaluation with a chat-only environment (no tools)."""
-
 from strands_env.core import Environment
 from strands_env.core.models import bedrock_model_factory, build_model_factory
 from strands_env.eval.benchmarks.hle_verified import HLEReward

--- a/examples/eval/hmmt/agentcore_code_env.py
+++ b/examples/eval/hmmt/agentcore_code_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for HMMT evaluation with `AgentCoreCodeEnv`."""
-
 from strands_env.core.models import build_model_factory
 from strands_env.environments.agentcore_code import AgentCoreCodeEnv
 from strands_env.environments.math.reward import MathVerifyReward

--- a/examples/eval/hmmt/chat_env.py
+++ b/examples/eval/hmmt/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for HMMT evaluation with a chat-only environment (no tools)."""
-
 from strands_env.core import Environment
 from strands_env.core.models import build_model_factory
 from strands_env.environments.math.reward import MathVerifyReward

--- a/examples/eval/ifeval/chat_env.py
+++ b/examples/eval/ifeval/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for IFEval with a chat-only environment (no tools)."""
-
 from strands_env.core import Environment
 from strands_env.core.models import build_model_factory
 from strands_env.eval.benchmarks.ifeval import IFEvalReward

--- a/examples/eval/mcp_atlas/env.py
+++ b/examples/eval/mcp_atlas/env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for MCP-Atlas evaluation."""
-
 from __future__ import annotations
 
 from strands_env.core.models import bedrock_model_factory, build_model_factory

--- a/examples/eval/sealqa/chat_env.py
+++ b/examples/eval/sealqa/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for SealQA evaluation with a chat-only environment (no tools)."""
-
 from strands_env.core import Environment
 from strands_env.core.models import bedrock_model_factory, build_model_factory
 from strands_env.eval.benchmarks.sealqa import SealQAReward

--- a/examples/eval/simple_math/math_env.py
+++ b/examples/eval/simple_math/math_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for math reasoning evaluation with `MathEnv`."""
-
 from strands_env.core.models import build_model_factory
 from strands_env.environments.math import MathEnv
 from strands_env.environments.math.reward import MathVerifyReward

--- a/examples/eval/simple_math/simple_math_evaluator.py
+++ b/examples/eval/simple_math/simple_math_evaluator.py
@@ -1,12 +1,3 @@
-"""Example evaluator hook for a simple math benchmark.
-
-This demonstrates how to create a custom evaluator for use with:
-    python -m strands_env.eval --evaluator examples.eval.simple_math.simple_math_evaluator \
-        --env examples.eval.simple_math.math_env --backend sglang
-
-The hook file must export `EvaluatorClass` (an Evaluator subclass).
-"""
-
 from collections.abc import Iterable
 
 from strands_env.core import Task

--- a/examples/eval/simpleqa_verified/chat_env.py
+++ b/examples/eval/simpleqa_verified/chat_env.py
@@ -1,5 +1,3 @@
-"""Example environment hook for SimpleQA-Verified evaluation with a chat-only environment (no tools)."""
-
 from strands_env.core import Environment
 from strands_env.core.models import bedrock_model_factory, build_model_factory
 from strands_env.eval.benchmarks.simpleqa_verified import SimpleQAReward

--- a/examples/eval/swe_bench/swe_bench_env.py
+++ b/examples/eval/swe_bench/swe_bench_env.py
@@ -1,9 +1,3 @@
-"""Environment hook for SWE-bench Verified evaluation with `HarborEnv`.
-
-The `swebench-verified` benchmark stamps a SWE-bench-tuned prompt onto each
-`HarborTask.system_prompt`, so this hook just instantiates the generic `HarborEnv`.
-"""
-
 from __future__ import annotations
 
 from strands_env.core.models import build_model_factory

--- a/examples/eval/tau2_bench/tau2_bench_env.py
+++ b/examples/eval/tau2_bench/tau2_bench_env.py
@@ -1,16 +1,3 @@
-"""Environment hook for tau2-bench evaluation with `Tau2BenchEnv`.
-
-The agent under test comes from the CLI model flags. The user-simulator and the
-NL-assertion judge default to `DEFAULT_USER_JUDGE_MODEL_CONFIG`; override them (or
-disable the judge with `null`) and set `max_steps` via ``--env-config``:
-
-    {
-        "user_model_config":  { ...ModelConfig... },   # optional: user-simulator
-        "judge_model_config": { ...ModelConfig... },   # optional: NL-assertion judge (null to disable)
-        "max_steps": 100                               # optional, default 100 (tau2 step semantics)
-    }
-"""
-
 from __future__ import annotations
 
 from typing import Any

--- a/examples/eval/terminal_bench/terminal_bench_env.py
+++ b/examples/eval/terminal_bench/terminal_bench_env.py
@@ -1,5 +1,3 @@
-"""Environment hook for terminal-bench evaluation with `HarborEnv`."""
-
 from __future__ import annotations
 
 from strands_env.core.models import build_model_factory

--- a/examples/math_demo.py
+++ b/examples/math_demo.py
@@ -1,18 +1,3 @@
-"""Math environment demo — shows how to use an Environment programmatically.
-
-This example demonstrates:
-- Creating a model factory
-- Instantiating an environment
-- Running rollouts and inspecting results
-
-Usage:
-    # SGLang backend (requires a running SGLang server)
-    python examples/math_demo.py --backend sglang
-
-    # Bedrock backend (requires AWS credentials)
-    python examples/math_demo.py --backend bedrock --model-id us.anthropic.claude-sonnet-4-20250514
-"""
-
 from __future__ import annotations
 
 import asyncio
@@ -90,7 +75,12 @@ async def run_demo(
     help="Base URL for SGLang server.",
 )
 def main(backend: str, model_id: str | None, base_url: str) -> None:
-    """Run math problems through a math environment."""
+    """Run math problems through a math environment.
+
+    \b
+    python examples/math_demo.py --backend sglang
+    python examples/math_demo.py --backend bedrock --model-id us.anthropic.claude-sonnet-4-20250514
+    """
     logging.basicConfig(level=logging.WARNING)
 
     asyncio.run(run_demo(backend, model_id, base_url))

--- a/examples/slime/retool/generate_with_agentcore_code.py
+++ b/examples/slime/retool/generate_with_agentcore_code.py
@@ -1,13 +1,3 @@
-"""
-Generate function for retool RL training using `strands-env`'s `AgentCoreCodeEnv`.
-
-Uses:
-- AWS Bedrock-based code execution
-- Built-in token tracking (Rollout)
-- Persistent session management
-- Tool iteration/call limits
-"""
-
 import logging
 
 from slime.rollout.sglang_rollout import GenerateState  # type: ignore

--- a/examples/web_search_demo.py
+++ b/examples/web_search_demo.py
@@ -1,20 +1,3 @@
-"""Web search environment demo — search the web and scrape pages for answers.
-
-This example demonstrates:
-- Creating a WebSearchEnv with search + scrape tools
-- Running rollouts and inspecting results
-- Cleaning up HTTP sessions
-
-Requires SERPER_API_KEY (or GOOGLE_API_KEY + GOOGLE_CSE_ID) env var.
-
-Usage:
-    # SGLang backend (requires a running SGLang server)
-    python examples/web_search_demo.py --backend sglang
-
-    # Bedrock backend (requires AWS credentials)
-    python examples/web_search_demo.py --backend bedrock --model-id us.anthropic.claude-sonnet-4-20250514
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/__init__.py
+++ b/src/strands_env/__init__.py
@@ -1,1 +1,0 @@
-"""A gym-like framework for building agent environments for RL training."""

--- a/src/strands_env/core/__init__.py
+++ b/src/strands_env/core/__init__.py
@@ -1,5 +1,3 @@
-"""Core module: environment, types, model factories, and shared reward/tool primitives."""
-
 from .environment import AsyncEnvFactory, Environment, EnvironmentConfig
 from .llm_judge_reward import JudgmentFormat, LLMJudgeReward
 from .mcp_tool import MCPToolAdapter

--- a/src/strands_env/core/distributed.py
+++ b/src/strands_env/core/distributed.py
@@ -1,5 +1,3 @@
-"""Ray actor pool for distributing `Environment.rollout()` across processes."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -1,5 +1,3 @@
-"""Base Environment class for Strands Agents."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/core/llm_judge_reward.py
+++ b/src/strands_env/core/llm_judge_reward.py
@@ -1,5 +1,3 @@
-"""LLM-as-judge reward function with optional structured output."""
-
 from __future__ import annotations
 
 import itertools

--- a/src/strands_env/core/mcp_tool.py
+++ b/src/strands_env/core/mcp_tool.py
@@ -1,10 +1,3 @@
-"""MCP tool adapter for Strands Agents.
-
-`MCPToolAdapter` is an `AgentTool` subclass that adapts an MCP tool definition to
-the Strands agent interface.  It handles tool spec building; subclasses implement
-`call_tool()` to provide the transport-specific call and result parsing.
-"""
-
 from __future__ import annotations
 
 from datetime import timedelta

--- a/src/strands_env/core/models.py
+++ b/src/strands_env/core/models.py
@@ -1,28 +1,3 @@
-"""Model factory functions for supported backends.
-
-Each function returns a `ModelFactory` (zero-arg callable that creates a fresh
-`Model` instance) for use with `Environment`::
-
-    from strands_sglang import SGLangClient
-    from strands_env.core.models import sglang_model_factory
-
-    client = SGLangClient("http://localhost:30000")
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B")
-    env = Environment(
-        model_factory=sglang_model_factory(tokenizer=tokenizer, client=client),
-    )
-
-Users can easily create their own model factories by implementing the `ModelFactory` type.
-
-Example:
-    >>> from strands_env.core.models import ModelFactory
-    >>> def my_model_factory() -> ModelFactory:
-    >>>     return lambda: MyModel()
-    >>>
-    >>> env = Environment(model_factory=my_model_factory())
-    >>>
-"""
-
 from __future__ import annotations
 
 import dataclasses

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -1,5 +1,3 @@
-"""Core types for Strands Agents Environments: tasks, rewards, model config, and rollout results."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/environments/__init__.py
+++ b/src/strands_env/environments/__init__.py
@@ -1,1 +1,0 @@
-"""Strands Agents Environments."""

--- a/src/strands_env/environments/agent_world_model/__init__.py
+++ b/src/strands_env/environments/agent_world_model/__init__.py
@@ -1,5 +1,3 @@
-"""AgentWorldModel MCP environment — synthetic FastAPI + SQLite tasks exposed via MCP."""
-
 from .env import AgentWorldModelConfig, AgentWorldModelEnv
 from .reward import AgentWorldModelReward
 from .task import AgentWorldModelTask

--- a/src/strands_env/environments/agent_world_model/env.py
+++ b/src/strands_env/environments/agent_world_model/env.py
@@ -1,5 +1,3 @@
-"""AgentWorldModel environment backed by a FastAPI + SQLite server subprocess."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/agent_world_model/reward.py
+++ b/src/strands_env/environments/agent_world_model/reward.py
@@ -1,8 +1,3 @@
-"""Reward function for AgentWorldModel tasks.
-
-Executes per-task `verify_task_completion` via `exec()` for binary reward.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/agent_world_model/server.py
+++ b/src/strands_env/environments/agent_world_model/server.py
@@ -1,5 +1,3 @@
-"""AgentWorldModel server script generation and lifecycle utilities."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/agent_world_model/task.py
+++ b/src/strands_env/environments/agent_world_model/task.py
@@ -1,5 +1,3 @@
-"""The per-sample input type for `AgentWorldModelEnv`."""
-
 from __future__ import annotations
 
 from pydantic import Field

--- a/src/strands_env/environments/agent_world_model/tool.py
+++ b/src/strands_env/environments/agent_world_model/tool.py
@@ -1,5 +1,3 @@
-"""AgentWorldModel MCP tool — calls the per-task FastAPI server via MCP session."""
-
 from __future__ import annotations
 
 import subprocess

--- a/src/strands_env/environments/agentcore_code/__init__.py
+++ b/src/strands_env/environments/agentcore_code/__init__.py
@@ -1,5 +1,3 @@
-"""AWS Bedrock AgentCore Code Interpreter environment."""
-
 from .env import AgentCoreCodeConfig, AgentCoreCodeEnv
 
 __all__ = ["AgentCoreCodeConfig", "AgentCoreCodeEnv"]

--- a/src/strands_env/environments/agentcore_code/env.py
+++ b/src/strands_env/environments/agentcore_code/env.py
@@ -1,5 +1,3 @@
-"""Code sandbox environment using AWS Bedrock AgentCore Code Interpreter."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/strands_env/environments/agentcore_code/quotas.py
+++ b/src/strands_env/environments/agentcore_code/quotas.py
@@ -1,5 +1,3 @@
-"""Shared AWS quotas for the Code Interpreter toolkit."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/agentcore_code/tool.py
+++ b/src/strands_env/environments/agentcore_code/tool.py
@@ -1,5 +1,3 @@
-"""Code sandbox toolkit using AWS Bedrock AgentCore Code Interpreter."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/harbor/__init__.py
+++ b/src/strands_env/environments/harbor/__init__.py
@@ -1,5 +1,3 @@
-"""Harbor task environment for Docker/e2b-based task evaluation."""
-
 from pathlib import Path
 
 from .env import HarborConfig, HarborEnv

--- a/src/strands_env/environments/harbor/e2b.py
+++ b/src/strands_env/environments/harbor/e2b.py
@@ -1,10 +1,3 @@
-"""Prebaked-template adapter for the Harbor `e2b` backend.
-
-Self-hosted e2b clusters may not implement Harbor's auto-build route, so
-`PrebakedE2BEnvironment` boots from a pre-baked `template_id` (resolved via a
-`templates.json` mapping or `E2B_TEMPLATES_PATH`) instead of building one.
-"""
-
 from __future__ import annotations
 
 import json

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -1,9 +1,3 @@
-"""Harbor task environment for container management and test execution.
-
-Runs a Harbor-format task in an isolated sandbox (Docker or self-hosted e2b): the agent
-solves it via a single `execute_command` tool and Harbor's `Verifier` grades the result.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -1,5 +1,3 @@
-"""Reward function for the Harbor task environment."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/harbor/task.py
+++ b/src/strands_env/environments/harbor/task.py
@@ -1,5 +1,3 @@
-"""The per-sample input type for `HarborEnv`."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/strands_env/environments/math/__init__.py
+++ b/src/strands_env/environments/math/__init__.py
@@ -1,5 +1,3 @@
-"""Chat-only math environment with a symbolic-equivalence reward."""
-
 from .env import MathEnv
 from .reward import MathVerifyReward
 

--- a/src/strands_env/environments/math/env.py
+++ b/src/strands_env/environments/math/env.py
@@ -1,5 +1,3 @@
-"""Math environment: no tools, symbolic-equivalence reward."""
-
 from pathlib import Path
 from typing import Unpack, override
 

--- a/src/strands_env/environments/math/reward.py
+++ b/src/strands_env/environments/math/reward.py
@@ -1,5 +1,3 @@
-r"""Symbolic-equivalence math reward backed by HuggingFace `math-verify`."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/environments/mcp_atlas/__init__.py
+++ b/src/strands_env/environments/mcp_atlas/__init__.py
@@ -1,5 +1,3 @@
-"""MCP-Atlas benchmark environment — Docker container with 36 MCP servers."""
-
 from .env import MCPAtlasConfig, MCPAtlasEnv
 from .reward import MCPAtlasReward
 from .task import MCPAtlasTask

--- a/src/strands_env/environments/mcp_atlas/env.py
+++ b/src/strands_env/environments/mcp_atlas/env.py
@@ -1,5 +1,3 @@
-"""MCP-Atlas environment backed by a Docker container."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/environments/mcp_atlas/reward.py
+++ b/src/strands_env/environments/mcp_atlas/reward.py
@@ -1,16 +1,3 @@
-"""Per-claim LLM-as-judge reward for MCP-Atlas (mirrors upstream `mcp_evals_scores.py`).
-
-Each GTFA claim is judged individually against the agent's response via
-structured output; scores are averaged into a coverage score.
-
-Scoring (from MCP-Atlas):
-    - `fulfilled` = 1.0
-    - `partially_fulfilled` = 0.5
-    - `not_fulfilled` = 0.0
-    - `coverage_score` = mean across claims
-    - pass threshold = 0.75
-"""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/environments/mcp_atlas/task.py
+++ b/src/strands_env/environments/mcp_atlas/task.py
@@ -1,5 +1,3 @@
-"""The per-sample input type for `MCPAtlasEnv`."""
-
 from __future__ import annotations
 
 from pydantic import Field

--- a/src/strands_env/environments/mcp_atlas/tool.py
+++ b/src/strands_env/environments/mcp_atlas/tool.py
@@ -1,5 +1,3 @@
-"""MCP-Atlas tool adapter — calls the container's REST API."""
-
 from __future__ import annotations
 
 from typing import Literal, override

--- a/src/strands_env/environments/tau2_bench/__init__.py
+++ b/src/strands_env/environments/tau2_bench/__init__.py
@@ -1,5 +1,3 @@
-"""tau2-bench environment: multi-turn customer-service eval (Sierra Research)."""
-
 from .env import Tau2BenchConfig, Tau2BenchEnv
 from .reward import Tau2BenchReward
 from .task import Tau2BenchTask

--- a/src/strands_env/environments/tau2_bench/_tau2.py
+++ b/src/strands_env/environments/tau2_bench/_tau2.py
@@ -1,13 +1,3 @@
-"""Single chokepoint for importing and accessing the optional `tau2` dependency.
-
-`tau2` reads `TAU2_DATA_DIR` into a frozen module global at import time
-(`tau2/utils/utils.py`), and `tau2/__init__.py` eagerly pulls that chain in — so
-tau2 must not be imported until the eval layer has configured the data dir.
-Routing every tau2 access through this module keeps the rest of the package
-import-pure and confines the workaround to one place. Do not `import tau2`
-anywhere else in the package.
-"""
-
 from __future__ import annotations
 
 from copy import deepcopy

--- a/src/strands_env/environments/tau2_bench/env.py
+++ b/src/strands_env/environments/tau2_bench/env.py
@@ -1,10 +1,3 @@
-"""tau2-bench environment.
-
-Multi-turn agent vs LLM user-sim over a shared in-memory DB. One `env.rollout()`
-runs the full episode inside a single `agent.invoke_async()`, driven turn-by-turn
-by `Tau2BenchUserSimulator` via `AfterInvocationEvent.resume` (strands-agents >= 1.30.0).
-"""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/environments/tau2_bench/nl_judge.py
+++ b/src/strands_env/environments/tau2_bench/nl_judge.py
@@ -1,5 +1,3 @@
-"""LLM judge for tau2's NL_ASSERTION sub-reward, aligned with tau2's judge prompt and schema."""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, override

--- a/src/strands_env/environments/tau2_bench/reward.py
+++ b/src/strands_env/environments/tau2_bench/reward.py
@@ -1,5 +1,3 @@
-"""Reward for tau2-bench: product of sub-rewards selected by `tau2_task.reward_basis`."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/environments/tau2_bench/simulator.py
+++ b/src/strands_env/environments/tau2_bench/simulator.py
@@ -1,16 +1,3 @@
-"""User-simulator side of tau2-bench: the LLM user and its dialogue protocol.
-
-`Tau2BenchUserSimulator` owns the user-side agent (persona prompt, user tools) and drives the
-whole multi-turn dialogue inside a single `agent.invoke_async()` by feeding each user
-reply back via `AfterInvocationEvent.resume`, until a stop marker
-(`###STOP###` / `###TRANSFER###` / `###OUT-OF-SCOPE###`) or the `max_steps` budget.
-
-`max_steps` mirrors tau2's step semantics: every message hop (agent message, tool round,
-user message) counts one step. It is enforced as a single budget over the total message
-count of both agents — a `LoopLimiter` on the user-sim agent is re-armed each turn with
-whatever the assistant conversation has not consumed.
-"""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/environments/tau2_bench/task.py
+++ b/src/strands_env/environments/tau2_bench/task.py
@@ -1,5 +1,3 @@
-"""The per-sample input type for `Tau2BenchEnv`."""
-
 from __future__ import annotations
 
 from functools import cached_property

--- a/src/strands_env/environments/tau2_bench/tool.py
+++ b/src/strands_env/environments/tau2_bench/tool.py
@@ -1,5 +1,3 @@
-"""Adapt a tau2 `Tool` to a Strands `AgentTool`."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/web_search/__init__.py
+++ b/src/strands_env/environments/web_search/__init__.py
@@ -1,5 +1,3 @@
-"""Web search environment with pluggable search providers."""
-
 from .env import WebSearchConfig, WebSearchEnv
 
 __all__ = ["WebSearchConfig", "WebSearchEnv"]

--- a/src/strands_env/environments/web_search/env.py
+++ b/src/strands_env/environments/web_search/env.py
@@ -1,5 +1,3 @@
-"""Web-search environment: search and optional scrape tools behind pluggable providers."""
-
 import asyncio
 from pathlib import Path
 from typing import Unpack, override

--- a/src/strands_env/environments/web_search/tools/__init__.py
+++ b/src/strands_env/environments/web_search/tools/__init__.py
@@ -1,5 +1,3 @@
-"""Tools for the web search environment."""
-
 from .scrape import WebScraperToolkit
 from .search import WebSearchAPIProvider, WebSearchToolkit
 

--- a/src/strands_env/environments/web_search/tools/scrape.py
+++ b/src/strands_env/environments/web_search/tools/scrape.py
@@ -1,5 +1,3 @@
-"""Web scraper toolkit with LLM structured summarization."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/environments/web_search/tools/search.py
+++ b/src/strands_env/environments/web_search/tools/search.py
@@ -1,5 +1,3 @@
-"""Web-search toolkit over Serper and Google Custom Search."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/eval/__init__.py
+++ b/src/strands_env/eval/__init__.py
@@ -1,5 +1,3 @@
-"""Evaluation framework for running agentic benchmarks."""
-
 from .evaluator import AsyncEnvFactory, EvalSample, Evaluator
 from .metrics import MetricFunction
 from .registry import get_benchmark, list_benchmarks, list_unavailable_benchmarks, register_eval

--- a/src/strands_env/eval/__main__.py
+++ b/src/strands_env/eval/__main__.py
@@ -1,5 +1,3 @@
-"""Module entry point for the evaluation CLI: `python -m strands_env.eval`."""
-
 from __future__ import annotations
 
 import os

--- a/src/strands_env/eval/benchmarks/__init__.py
+++ b/src/strands_env/eval/benchmarks/__init__.py
@@ -1,5 +1,0 @@
-"""Benchmark evaluator modules.
-
-Each module in this package defines benchmark evaluators using @register_eval.
-Modules with missing dependencies are skipped during discovery.
-"""

--- a/src/strands_env/eval/benchmarks/aime.py
+++ b/src/strands_env/eval/benchmarks/aime.py
@@ -1,5 +1,3 @@
-"""Evaluator for AIME (American Invitational Mathematics Examination) benchmarks."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/eval/benchmarks/browsecomp.py
+++ b/src/strands_env/eval/benchmarks/browsecomp.py
@@ -1,5 +1,3 @@
-"""Evaluator for BrowseComp benchmark."""
-
 from __future__ import annotations
 
 import base64

--- a/src/strands_env/eval/benchmarks/frames.py
+++ b/src/strands_env/eval/benchmarks/frames.py
@@ -1,5 +1,3 @@
-"""Evaluator for FRAMES (Factuality, Retrieval, And reasoning MEasurement Set) benchmark."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/eval/benchmarks/gpqa.py
+++ b/src/strands_env/eval/benchmarks/gpqa.py
@@ -1,5 +1,3 @@
-"""Evaluator for GPQA (Graduate-Level Google-Proof Q&A) benchmarks."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/eval/benchmarks/hle_verified.py
+++ b/src/strands_env/eval/benchmarks/hle_verified.py
@@ -1,5 +1,3 @@
-"""Evaluator for HLE-Verified benchmark (Gold subset)."""
-
 from __future__ import annotations
 
 import base64

--- a/src/strands_env/eval/benchmarks/hmmt.py
+++ b/src/strands_env/eval/benchmarks/hmmt.py
@@ -1,5 +1,3 @@
-"""Evaluator for HMMT (Harvard-MIT Mathematics Tournament) benchmarks."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/eval/benchmarks/ifeval.py
+++ b/src/strands_env/eval/benchmarks/ifeval.py
@@ -1,5 +1,3 @@
-"""Evaluator for IFEval (Instruction-Following Eval) benchmark."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/eval/benchmarks/mcp_atlas.py
+++ b/src/strands_env/eval/benchmarks/mcp_atlas.py
@@ -1,5 +1,3 @@
-"""Evaluator for MCP-Atlas benchmark."""
-
 from __future__ import annotations
 
 import ast

--- a/src/strands_env/eval/benchmarks/sealqa.py
+++ b/src/strands_env/eval/benchmarks/sealqa.py
@@ -1,5 +1,3 @@
-"""Evaluator for SealQA (Search-Augmented Language models QA) benchmarks."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/eval/benchmarks/simpleqa_verified.py
+++ b/src/strands_env/eval/benchmarks/simpleqa_verified.py
@@ -1,5 +1,3 @@
-"""Evaluator for SimpleQA-Verified benchmarks."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/eval/benchmarks/swebench.py
+++ b/src/strands_env/eval/benchmarks/swebench.py
@@ -1,10 +1,3 @@
-"""Evaluator for SWE-bench Verified (Harbor format).
-
-The Harbor-format SWE-bench Verified tasks live as a subdirectory inside
-the larger `harbor-datasets.git` repo. We sparse-checkout just that
-subdirectory at a pinned commit so we don't have to clone every benchmark.
-"""
-
 from __future__ import annotations
 
 import subprocess

--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -1,5 +1,3 @@
-"""Evaluator for tau2-bench (Sierra Research, multi-turn customer service)."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/eval/benchmarks/terminal_bench.py
+++ b/src/strands_env/eval/benchmarks/terminal_bench.py
@@ -1,5 +1,3 @@
-"""Evaluator for Terminal-Bench (Harbor) benchmarks."""
-
 from __future__ import annotations
 
 import json

--- a/src/strands_env/eval/cli.py
+++ b/src/strands_env/eval/cli.py
@@ -1,5 +1,3 @@
-"""Evaluation CLI commands."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -1,5 +1,3 @@
-"""Evaluator for running agentic benchmarks with Strands Agents Environments."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/eval/metrics.py
+++ b/src/strands_env/eval/metrics.py
@@ -1,5 +1,3 @@
-"""Evaluation metrics for benchmark results."""
-
 from __future__ import annotations
 
 import math

--- a/src/strands_env/eval/registry.py
+++ b/src/strands_env/eval/registry.py
@@ -1,9 +1,3 @@
-"""Benchmark registry with auto-discovery.
-
-Evaluator modules are discovered and imported on first registry access.
-Benchmarks with missing optional dependencies are skipped with a warning.
-"""
-
 from __future__ import annotations
 
 import importlib

--- a/src/strands_env/eval/reporter.py
+++ b/src/strands_env/eval/reporter.py
@@ -1,5 +1,3 @@
-"""Pluggable result sinks for the eval `Evaluator`."""
-
 from __future__ import annotations
 
 import json

--- a/src/strands_env/utils/__init__.py
+++ b/src/strands_env/utils/__init__.py
@@ -1,1 +1,0 @@
-"""Utilities for `strands_env`."""

--- a/src/strands_env/utils/aws.py
+++ b/src/strands_env/utils/aws.py
@@ -1,5 +1,3 @@
-"""Utilities for AWS boto3 session."""
-
 from __future__ import annotations
 
 import logging

--- a/src/strands_env/utils/decorators.py
+++ b/src/strands_env/utils/decorators.py
@@ -1,5 +1,3 @@
-"""Decorator and utility function helpers for `strands_env`."""
-
 from __future__ import annotations
 
 import asyncio

--- a/src/strands_env/utils/loader.py
+++ b/src/strands_env/utils/loader.py
@@ -1,5 +1,3 @@
-"""Generic module/function/hook loading utilities."""
-
 from __future__ import annotations
 
 import importlib

--- a/src/strands_env/utils/slime_logger.py
+++ b/src/strands_env/utils/slime_logger.py
@@ -1,17 +1,3 @@
-"""Rollout logger for `slime` training, with a pluggable logging backend.
-
-`RolloutLogger` aggregates per-rollout environment metrics into slime's
-`rollout_extra_metrics` and publishes a sample of decoded rollouts to the
-configured `backend`:
-
-- `"wandb"` — metrics to `wandb`, samples to a W&B Weave dataset.
-- `"mlflow"` — metrics and samples to MLflow.
-
-Instantiate one and pass its bound `log_rollouts` as slime's
-`--custom-rollout-log-function-path` callback. Backend libraries are imported
-lazily, so only the selected backend needs to be installed.
-"""
-
 from __future__ import annotations
 
 import logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,3 @@
-"""Root pytest configuration for strands-env tests.
-
-Test Structure:
-    tests/unit/        - Unit tests (no external dependencies)
-    tests/integration/ - Integration tests (require SGLang server)
-
-Running Tests:
-    pytest tests/unit/                    # Unit tests only
-    pytest tests/integration/ -v          # Integration tests (require SGLang server)
-
-Configuration:
-    pytest tests/integration/ --sglang-base-url=http://localhost:30000
-
-    Or via environment variables:
-    SGLANG_BASE_URL=http://localhost:30000 pytest tests/integration/
-"""
-
 import os
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,14 +1,3 @@
-"""Shared fixtures for integration tests.
-
-All tests in this directory require a running SGLang server.
-The model ID is auto-detected from the server via /model_info.
-Tests are skipped automatically if the server is not reachable.
-
-Configuration (priority: CLI > env var > default):
-    pytest --sglang-base-url=http://localhost:30000 --tool-parser=hermes
-    SGLANG_BASE_URL=http://... TOOL_PARSER=hermes pytest tests/integration/
-"""
-
 import pytest
 from strands_sglang import SGLangClient
 from strands_sglang.tool_parsers import get_tool_parser

--- a/tests/integration/test_agentcore_code.py
+++ b/tests/integration/test_agentcore_code.py
@@ -1,10 +1,3 @@
-"""Integration tests for AgentCoreCodeEnv with a real SGLang model.
-
-Requires:
-- A running SGLang server (default: http://localhost:30000)
-- Valid AWS credentials with Bedrock AgentCore access
-"""
-
 import pytest
 
 from strands_env.core.types import RewardResult, RolloutResult, Task, TerminationReason

--- a/tests/integration/test_harbor.py
+++ b/tests/integration/test_harbor.py
@@ -1,11 +1,3 @@
-"""Integration tests for HarborEnv with a real SGLang model.
-
-Requires:
-- A running SGLang server (default: http://localhost:30000)
-- Docker daemon running
-- harbor>=0.1.43 (`pip install harbor`)
-"""
-
 import shutil
 import subprocess
 

--- a/tests/integration/test_math_env.py
+++ b/tests/integration/test_math_env.py
@@ -1,11 +1,3 @@
-"""Integration tests for MathEnv.
-
-Exercises the full rollout lifecycle: agent invocation → result
-(messages, tokens, metrics) → optional reward — against a real SGLang model.
-
-Requires a running SGLang server (default: http://localhost:30000).
-"""
-
 from strands_env.core.types import Task, TerminationReason
 from strands_env.environments.math import MathEnv
 from strands_env.environments.math.reward import MathVerifyReward

--- a/tests/integration/test_web_search.py
+++ b/tests/integration/test_web_search.py
@@ -1,11 +1,3 @@
-"""Integration tests for WebSearchEnv.
-
-Requires:
-    - A running SGLang server (auto-skipped if unreachable)
-    - SERPER_API_KEY env var for Serper provider tests
-    - GOOGLE_API_KEY + GOOGLE_CSE_ID env vars for Google provider tests
-"""
-
 import os
 
 import pytest

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,3 @@
-"""Shared fixtures and helpers for unit tests."""
-
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -1,5 +1,3 @@
-"""Fixtures scoped to core/ tests."""
-
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/unit/core/test_environment.py
+++ b/tests/unit/core/test_environment.py
@@ -1,5 +1,3 @@
-"""Unit tests for Environment."""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/unit/core/test_llm_judge_reward.py
+++ b/tests/unit/core/test_llm_judge_reward.py
@@ -1,5 +1,3 @@
-"""Unit tests for LLMJudgeReward error recovery and happy paths."""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pydantic import BaseModel

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -1,5 +1,3 @@
-"""Unit tests for model factory functions."""
-
 from unittest.mock import MagicMock, patch
 
 import boto3

--- a/tests/unit/core/test_types.py
+++ b/tests/unit/core/test_types.py
@@ -1,5 +1,3 @@
-"""Unit tests for core types."""
-
 import pytest
 from botocore.exceptions import ClientError
 from strands.types.exceptions import (

--- a/tests/unit/environments/agentcore_code/test_code_interpreter.py
+++ b/tests/unit/environments/agentcore_code/test_code_interpreter.py
@@ -1,5 +1,3 @@
-"""Unit tests for CodeInterpreterQuotas and CodeInterpreterToolkit."""
-
 import asyncio
 import time
 from unittest.mock import MagicMock

--- a/tests/unit/environments/harbor/test_e2b.py
+++ b/tests/unit/environments/harbor/test_e2b.py
@@ -1,11 +1,3 @@
-"""Unit tests for the Harbor `e2b` backend adapter (`e2b.py`).
-
-Covers the harbor-independent logic: template resolution, connection env-var
-export, the permissive api-key validator, and the `PrebakedE2BEnvironment`
-`__init__`/`start` overrides. Harbor's `E2BEnvironment` base and the e2b SDK are
-not exercised against a real cluster — sandbox creation is mocked.
-"""
-
 from __future__ import annotations
 
 import json

--- a/tests/unit/environments/harbor/test_env.py
+++ b/tests/unit/environments/harbor/test_env.py
@@ -1,12 +1,3 @@
-"""Unit tests for `HarborConfig` type resolution.
-
-Regression guard: `HarborConfig` (with its nested `PrebakedE2BConfig` and the
-inherited base knobs) is embedded as a Pydantic field by the
-terminal-bench / swebench task contexts. Pydantic resolves those hints at
-runtime, so a TYPE_CHECKING-only type in any `HarborConfig` field breaks dataset
-loading with a `NameError`.
-"""
-
 from __future__ import annotations
 
 import typing

--- a/tests/unit/environments/math/test_math_verify_reward.py
+++ b/tests/unit/environments/math/test_math_verify_reward.py
@@ -1,5 +1,3 @@
-"""Tests for MathVerifyReward."""
-
 from strands_env.core.types import RolloutResult, Task
 from strands_env.environments.math.reward import MathVerifyReward
 

--- a/tests/unit/environments/tau2_bench/test_lazy_import.py
+++ b/tests/unit/environments/tau2_bench/test_lazy_import.py
@@ -1,14 +1,3 @@
-"""Import-hygiene test for the tau2-bench package.
-
-`tau2` reads `TAU2_DATA_DIR` into a frozen module global at import time and
-`tau2/__init__.py` eagerly pulls that chain in, so nothing in the package may
-import tau2 at module load — every tau2 access is funnelled through `_tau2.py`'s
-lazy accessors. This locks the invariant in: a future top-level `import tau2`
-(or a hoisted inline import) fails here instead of silently breaking the eval
-data-dir ordering. Runs in a subprocess so a clean `sys.modules` is guaranteed
-regardless of what the rest of the test session imported.
-"""
-
 from __future__ import annotations
 
 import subprocess

--- a/tests/unit/environments/tau2_bench/test_simulator.py
+++ b/tests/unit/environments/tau2_bench/test_simulator.py
@@ -1,9 +1,3 @@
-"""Unit tests for Tau2BenchUserSimulator.
-
-Patches the `Agent` class inside the simulator module so no model or server is needed,
-then feeds real `AfterInvocationEvent` objects to exercise the actual hook path.
-"""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/unit/environments/web_search/test_scrape.py
+++ b/tests/unit/environments/web_search/test_scrape.py
@@ -1,10 +1,3 @@
-"""Unit tests for `WebScraperToolkit`.
-
-Some tests compare our behavior to OpenSeeker's upstream `visit.py` to flag
-unintended divergences. Upstream reference:
-https://github.com/rui-ye/OpenSeeker/blob/main/src/tools/visit.py
-"""
-
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/unit/environments/web_search/test_search.py
+++ b/tests/unit/environments/web_search/test_search.py
@@ -1,5 +1,3 @@
-"""Unit tests for WebSearchToolkit pure-logic methods."""
-
 from strands_env.environments.web_search.tools.search import WebSearchToolkit
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/conftest.py
+++ b/tests/unit/eval/conftest.py
@@ -1,5 +1,3 @@
-"""Fixtures shared by the eval unit tests."""
-
 from __future__ import annotations
 
 from collections.abc import Iterator

--- a/tests/unit/eval/test_evaluator.py
+++ b/tests/unit/eval/test_evaluator.py
@@ -1,5 +1,3 @@
-"""Unit tests for evaluation module (evaluator + metrics)."""
-
 import json
 import logging
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/eval/test_registry.py
+++ b/tests/unit/eval/test_registry.py
@@ -1,5 +1,3 @@
-"""Unit tests for benchmark registry."""
-
 import pytest
 
 from strands_env.eval import Evaluator, get_benchmark, list_benchmarks

--- a/tests/unit/eval/test_reporter.py
+++ b/tests/unit/eval/test_reporter.py
@@ -1,5 +1,3 @@
-"""Unit tests for eval reporters (EvalReporter, LocalReporter, CompositeReporter)."""
-
 from __future__ import annotations
 
 import json

--- a/tests/unit/eval/test_terminal_bench.py
+++ b/tests/unit/eval/test_terminal_bench.py
@@ -1,5 +1,3 @@
-"""Unit tests for the Terminal-Bench (Harbor) evaluators."""
-
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,5 +1,3 @@
-"""Tests for utils/aws.py and utils/decorators.py."""
-
 import threading
 import time
 from datetime import UTC


### PR DESCRIPTION
## Module docstrings

Every `.py` file opened with a one-line locator restating what its path already says — "Evaluator for IFEval", "Reward function for AgentWorldModel tasks", "Math environment: no tools". 120 files across `src/`, `tests/` and `examples/`. Gone; a file now starts at its first import. `D100`/`D104` stay unselected so nothing puts them back.

Thirteen were multi-line and carried real context. Two worth naming:

- **`_tau2.py`** explained why nothing may `import tau2` directly (it freezes `TAU2_DATA_DIR` at import time). That constraint is already in AGENTS.md and enforced by `test_lazy_import.py`, so nothing was lost.
- **`math_demo.py`** held the two concrete invocations. Moved into the click command's docstring, where `--help` now prints them — more discoverable than a module header.

## The four missing style sections

You flagged that tokin's Style section never got synced. Adding Files, Comments, Private helpers, Module-level private functions, and Tests — these conventions existed only as review habits.

**Two are adapted rather than copied, because the borrowed thresholds contradict this codebase:**

| Rule as written there | Here | Why |
|---|---|---|
| "Under four lines: inline it" | "look for a reason to keep it" | `_get_session` is 3 lines and earns them — "reopen if the session closed" belongs in one place, not at 5 call sites |
| "Keep private under ~20% of a module" | a smell, not a limit | `Tau2BenchReward` is 4/6 private because tau2 defines four sub-rewards (`_db_reward`, `_action_reward`, …) and the class exists to combine them |

The test I wrote down instead: whether each private name is a domain concept, or a stage of one procedure that got sliced up.

**Tests** describes what the suite already does rather than prescribing a rewrite: group into a class named for the unit under test once there are three or more scenarios (47 of our classes qualify), module-level function below that. Docstrings on tests stay *optional* rather than banned — a regression whose trigger needs naming is worth a line.

## Verified

121 files changed, −486 lines. ruff, ruff-format, mypy clean; 315 unit tests pass; `--help` on the demo checked by hand.