### PR TITLE
build: stop dependabot bumping e2b

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,12 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    ignore:
+      # Pinned to `==` on purpose: e2b.py monkeypatches `e2b.api.validate_api_key`
+      # so self-hosted clusters' non-hex keys pass, and patching a renamed target
+      # fails silently at auth time rather than at import. Prebaked template ids
+      # are tied to the SDK version too. Upgrade by hand against a real cluster.
+      - dependency-name: e2b
     groups:
       # Dev tooling lands as one PR; runtime deps stay separate so a break is easy to bisect.
       dev:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ Issues = "https://github.com/strands-rl/strands-env/issues"
 [project.optional-dependencies]
 harbor = [
     "harbor>=0.15.0",
+    # Exact pin: `e2b.py` patches an SDK internal. See dependabot.yml's ignore entry.
     "e2b==2.25.1",
 ]
 ifeval = ["lm_eval[ifeval]>=0.4.11"]


### PR DESCRIPTION
Dependabot opened #231 rewriting `e2b==2.25.1` → `==2.38.0`. It treats an exact pin as a version to raise, the same way it widened the mypy ceiling from `<2.0.0` to `<3.0.0` in #220.

## Why that pin is load-bearing

`environments/harbor/e2b.py` assigns over an SDK internal:

```python
# Relax the SDK's hex-only key check before any Sandbox is constructed;
# self-hosted clusters use a broader key alphabet.
_e2b_api.validate_api_key = validate_api_key
```

Patching a module attribute that a release has renamed or moved **raises nothing at import**. It surfaces later as an authentication failure when a sandbox is constructed — in a training run, not in CI. The prebaked template ids resolved in the same file are tied to the SDK version too.

So this isn't a pin someone forgot to relax; upgrading e2b means running the harbor integration tests against a real self-hosted cluster. That's manual work, not a green lockfile diff.

## What this does

An `ignore` entry for `e2b` in `dependabot.yml`, with the reason recorded at both sites — the config and the pin itself, since that's where the next person looks.

#231 closed with the same explanation.

`agent-world-model==0.1.0` needs no entry: 0.1.0 is the only release on PyPI, so there's nothing for dependabot to bump, and its pin already carries a comment about the fastapi conflict with harbor.