### PR TITLE
docs: fix two stale claims in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ uv sync --extra harbor     # plus an optional extra
 
 ### Linting
 ```bash
+pre-commit run --all-files   # what CI's lint job runs; the individual tools below are a subset
 ruff check src/ tests/ examples/
 ruff format --check src/ tests/ examples/
 mypy src/strands_env
@@ -243,9 +244,9 @@ Enum members are the exception to everything above: bare UPPER assignments, neve
 
 ## Releases
 
-- Do NOT push tags (`git push --tags`) - the user will create GitHub Releases manually to trigger PyPI CI/CD
-- When preparing a release: update version in `pyproject.toml`, commit, push code only
-- User creates the release on GitHub web UI which triggers the publish workflow
+- Do NOT push tags (`git push --tags`) — the user creates the GitHub Release manually, which triggers `publish.yml`
+- There is no version to bump: `hatch-vcs` derives it from the git tag the release creates
+- Get the number right the first time. The `tags-are-immutable` ruleset blocks moving or deleting a tag, and PyPI refuses a second upload of the same filename
 
 ## Maintenance
 


### PR DESCRIPTION
Two instructions that would send someone down a wrong path.

**The release checklist said to "update version in `pyproject.toml`"** — there is no version field there. `hatch-vcs` derives it from the git tag the release creates, so following that step means hunting for something that doesn't exist. Replaced with the two facts that actually constrain a release: nothing to bump, and the number is one-shot (the `tags-are-immutable` ruleset blocks moving a tag, and PyPI refuses a duplicate filename).

**The Linting block listed ruff and mypy as if they were the gate.** Since #217 the gate is `pre-commit run --all-files`, which also covers typos, zizmor, the workflow/dependabot schema checks, and uv-lock — so running only the three listed commands can still leave a PR red. Added the real command above them rather than removing the individual ones, which are still useful for a quick loop.