### PR TITLE
style: cut docstring sections that repeat the signature (core, utils)

### DIFF
--- a/.claude/commands/audit-docstrings.md
+++ b/.claude/commands/audit-docstrings.md
@@ -1,0 +1,87 @@
+Audit a package's docstrings and comments against the style rules in AGENTS.md, and fix what fails.
+
+Target is $ARGUMENTS — a package or file path under `src/strands_env/` (e.g. `eval`,
+`environments/harbor`, `core/models.py`). If not provided, ask which one; never audit
+everything at once.
+
+## Read the files. Do not grep for candidates.
+
+A script cannot tell a `# ---- Task ----` section divider from an explanatory comment, or
+judge whether a private helper names a domain concept. Open each file in the target and
+read it. Counting tools are for reporting scale, not for deciding.
+
+## The decisions, in the order they resolve
+
+**1. `Args:` is all-or-nothing.** `D417` rejects a partial section, so the question is
+never "does this parameter need a line" but "do this function's parameters need
+explaining at all". Default no.
+
+Delete the whole section when every line restates its annotation:
+
+```python
+client: SGLangClient            # signature
+    client: `SGLangClient` for HTTP communication with the server.   # the same fact
+```
+
+Keep it when a parameter's meaning isn't in its type: resolution order, ownership, what
+`None` falls back to, units, what happens when two arguments disagree, or a name that
+implies less than it does (`env_hook_path: str` is really a dotted path to a callable
+returning an `AsyncEnvFactory`).
+
+**2. `Returns:`/`Yields:` earn their place against the annotation.**
+`-> tuple[list[ToolResultContent], Literal["success", "error"]]` needs no "a tuple of
+(content, status)". A `-> str` that is really a JSON envelope does. The poorer the type,
+the more the section is worth.
+
+**3. `Notes:` is a footnote; the body is the explanation.** Delete the sentence and see
+what breaks. If the function stops making sense it was body text — why this method
+exists, which of two paths to take, what an empty return means. If all that's lost is a
+warning, it stays a footnote: thread-safety, a teardown contract, an upstream quirk, a
+deliberate divergence from a reference implementation.
+
+One `Notes:` holding three unrelated facts means none of them got classified. Split it.
+
+**4. A docstring that restates its identifier goes.** `"""Return the tool name."""` on
+`tool_name` says nothing; `D1` is unselected precisely so it can be absent.
+
+**5. Comments state the why, on the line they explain.** Cut the ones narrating the next
+statement ("Return the sample with the aborted flag set" above `sample = EvalSample(...)`).
+Keep the ones a reader would otherwise undo ("Dropped by default: a full token trajectory
+per sample bloats results.jsonl").
+
+**6. Class-level `Args:` describing `__init__` parameters moves onto `__init__`.** Keep
+the content, relocate it to where the parameters are.
+
+## Exempt
+
+- `@tool` method docstrings — agent-facing specs, the model reads them
+- Section dividers (`# ---- Reward ----`)
+- Pydantic `Field(description=...)` — serialized into task records
+- Module docstrings: there are none, and none should be added (`D100`/`D104` unselected)
+
+## Verify the claims you make
+
+Any docstring asserting a fact about the code is a claim to check while you're there.
+Past audits found three that were wrong, all of them silent:
+
+- `requires_env` documented `EnvironmentError`, the code raises `OSError`
+- `with_timeout` documented `_TimeoutInterrupt`, the class is `TimeoutInterrupt`
+- `log_rollout_metrics` said `generate()` must set `sample.metrics`; it reads
+  `sample.result.metrics`, so following the docstring would not have made it work
+
+Grep the identifier. Check the exception type. Read the attribute the prose names.
+
+## Finish
+
+1. `.venv/bin/pre-commit run --all-files` — must be clean. `D205` (blank line after
+   summary) and `D415` (summary ends with a period) are the two that bite when reflowing.
+2. Report per file: what changed and why, plus anything you deliberately left. State the
+   line delta.
+3. Commit per package, not per file. The commit message names the defect classes found,
+   and calls out any factual error separately — those are the part worth reviewing.
+
+## Don't
+
+- Rewrite working prose for taste. Fix the disease, keep the healthy tissue.
+- Leave a file half-done. Two styles side by side is worse than either.
+- Add a docstring that wasn't there because the function looks bare.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guidance for coding agents working in this repository. `CLAUDE.md` points here.
+Guidance for coding agents working in this repository. `CLAUDE.md` is a symlink to this file.
 
 ## Project Overview
 
@@ -156,7 +156,11 @@ signature genuinely doesn't carry the fact, so it stays documented:
 
 - **Class**: one-line summary; facts the signature can't show (lifecycle, resource ownership) go in `Notes:`.
 - **Config TypedDicts**: first line "Serializable configuration for `XxxEnv`."; each field gets an inline comment with its default (`# seconds per MCP tool call (default 60)`) — the default otherwise hides in a distant `.get()`.
-- **`__init__`**: NO docstring when parameters are self-evident — its presence is the signal that something needed saying. Write a full `Args:` section only when parameters carry semantics: ownership, sharing, fallback behavior.
+- **`Args:` is all-or-nothing.** `D417` fails a partial section, so the question is never "does this parameter need a line" but "do this function's parameters need explaining at all". Default no — the name and the annotation carry it. Write the section when a parameter's meaning isn't in its type: resolution order, ownership, what `None` falls back to, units, what happens when two arguments disagree. One line per parameter that only restates the annotation is the signal the whole section should go.
+- **`Notes:` is a footnote, the body is the explanation.** The test: delete the sentence. If the function no longer makes sense, it was body text (why this method exists, which of two paths to take, what an empty return means). If all that's lost is a warning, it belongs under `Notes:` (thread-safety, a teardown contract, an upstream quirk, a deliberate divergence from a reference implementation). One `Notes:` holding three unrelated facts means none of them got classified — split them. Never put a function-level constraint in `Args:`; a parameter line explains that parameter.
+- **`Returns:`/`Yields:` earn their place against the annotation, not the reader's curiosity.** `-> tuple[list[ToolResultContent], Literal["success", "error"]]` needs no "a tuple of (content, status)". A `-> str` that is really a JSON envelope does: `EnvironmentActor.rollout` documents "JSON string, reconstruct via `RolloutResult.model_validate_json()`" because the annotation cannot say that. Rule of thumb: the poorer the type, the more the section is worth.
+- **`Raises:` only for exceptions a caller is expected to catch**, not every one that can escape. **`Example:`** only where usage isn't guessable from the signature — a base class whose contract spans several overridden methods is the case that qualifies. Nothing else: no `Attributes:`, no `Warning:`, no `Todo:`.
+- **`__init__`**: NO docstring when parameters are self-evident — its presence is the signal that something needed saying.
 - **Methods**: one imperative line saying what the signature can't; overrides state what this implementation does differently.
 - **Task classes**: the class line says what one sample IS ("One Harbor-format task bundle on disk, plus where this trial writes its outputs."). `Field(description=...)` per field, carrying semantics, not restating types. Tasks may own data-derived views of their fields (path wrappers, world materialization) but never scoring behavior — that lives on `RewardFunction`.
 - **Env classes**: domain-first summaries ("Web-search environment with ...", "Code sandbox environment using ..."), matching the family pattern.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+AGENTS.md

--- a/src/strands_env/core/distributed.py
+++ b/src/strands_env/core/distributed.py
@@ -21,16 +21,13 @@ logger = logging.getLogger(__name__)
 class EnvironmentActor:
     """Remote worker that runs environment episodes in a dedicated process.
 
-    The actor is fully generic — it loads a callable via dotted path and
-    calls it with the provided kwargs to produce an `AsyncEnvFactory`.
-    All domain logic (model construction, reward setup, etc.) lives in the hook.
-
-    Args:
-        env_hook_path: Dotted path to a callable that returns an `AsyncEnvFactory`.
-        env_hook_config: Configuration passed to the hook callable.
+    Fully generic: it loads a callable via dotted path and calls it with the provided kwargs to
+    produce an `AsyncEnvFactory`, so all domain logic (model construction, reward setup) lives in
+    the hook rather than here.
     """
 
     def __init__(self, env_hook_path: str, env_hook_config: dict[str, Any]) -> None:
+        """`env_hook_path` is a dotted path to a callable returning an `AsyncEnvFactory`."""
         env_hook = load_function(env_hook_path)
         self.env_factory = env_hook(**env_hook_config)
 
@@ -73,13 +70,9 @@ class EnvironmentActor:
 class EnvironmentActorPool:
     """Pool of `EnvironmentActor` instances distributed across Ray nodes.
 
-    Each actor runs in its own process with a separate GIL and event loop,
-    enabling true CPU parallelism for agent episodes.
-
-    Args:
-        env_hook_path: Dotted path to a callable that returns an `AsyncEnvFactory`.
-        env_hook_config: Configuration passed to the hook callable in each actor.
-        n_actors_per_node: Number of actors per alive Ray node.
+    Each actor runs in its own process with a separate GIL and event loop, giving true CPU
+    parallelism for agent episodes. `env_hook_path` is a dotted path to a callable returning an
+    `AsyncEnvFactory`, called with `env_hook_config` inside every actor.
     """
 
     def __init__(

--- a/src/strands_env/core/environment.py
+++ b/src/strands_env/core/environment.py
@@ -84,15 +84,13 @@ class Environment(Generic[TaskT]):
     async def reset(self, _task: TaskT) -> None:
         """Build the episode for `task`. Override for environment-specific init.
 
-        Called by `rollout()` before the agent runs — gym-style, the task enters here.
+        Called by `rollout()` before the agent runs — gym-style, the task enters here. This is where
+        resource-heavy or async setup belongs (containers, sessions, connections), since `__init__`
+        cannot `await`.
 
         Notes:
-            - This is the right place for resource-heavy or async initialization
-            (e.g., spinning up containers, creating sessions, connecting to services).
-            - Keep `__init__` limited to storing run-level config and lightweight
-            state — it is synchronous and cannot `await`.
-            - Paired with `cleanup`, which tears down what `reset` sets up and must
-            tolerate partially-initialized state (`reset` may fail midway).
+            Paired with `cleanup`, which tears down what `reset` sets up and must tolerate
+            partially-initialized state, because `reset` may fail midway.
         """
 
     async def rollout(self, task: TaskT) -> RolloutResult:

--- a/src/strands_env/core/llm_judge_reward.py
+++ b/src/strands_env/core/llm_judge_reward.py
@@ -21,24 +21,15 @@ JudgmentFormat = TypeVar("JudgmentFormat", bound=BaseModel)
 class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
     r"""Abstract base for LLM-as-judge reward functions.
 
-    Args:
-        judge_model: A single model or a list of models to round-robin across
-            (useful for spreading load across AWS profiles to avoid throttling).
-            The cycle advances per sample, so consecutive judgments hit different
-            profiles.
-        default_reward: Reward to return if the judge fails.
+    Subclasses set the `judgment_format` class attribute and implement `get_judge_prompt` and
+    `get_reward`. With `judgment_format` set, the judge uses structured output and `get_reward`
+    receives the parsed Pydantic model; with `None`, it receives the raw text.
 
     Notes:
-        - Subclasses set `judgment_format` class attribute and implement
-          `get_judge_prompt` and `get_reward`.
-        - When `judgment_format` is set, uses structured output and passes
-          the parsed Pydantic model to `get_reward`. When `None`, passes
-          the raw text response instead.
-        - Throttling is handled by Strands' `ModelRetryStrategy`, a default hook on
-          every `Agent`: 6 attempts with exponential backoff (`4+8+16+32+64` = ~124s)
-          before a `ModelThrottledException` surfaces here as `judge_error`. Override
-          `get_judge_agent` to tune it (`retry_strategy=ModelRetryStrategy(...)`), or
-          to add a hook that rotates `agent.model` between attempts.
+        Throttling is handled by Strands' `ModelRetryStrategy`, a default hook on every `Agent`:
+        6 attempts with exponential backoff (`4+8+16+32+64` = ~124s) before a
+        `ModelThrottledException` surfaces here as `judge_error`. Override `get_judge_agent` to
+        tune it, or to add a hook that rotates `agent.model` between attempts.
 
     Example:
         class SimpleQAReward(LLMJudgeReward[SimpleQAJudgment]):
@@ -60,6 +51,11 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
         *,
         default_reward: float = 0.0,
     ) -> None:
+        """A list of judge models is round-robined, advancing once per sample.
+
+        Useful for spreading load across AWS profiles to avoid throttling, so consecutive
+        judgments hit different profiles.
+        """
         self.judge_models = itertools.cycle(judge_model if isinstance(judge_model, list) else [judge_model])
         self.default_reward = default_reward
 
@@ -70,16 +66,16 @@ class LLMJudgeReward(RewardFunction[TaskT], Generic[JudgmentFormat, TaskT]):
     @abstractmethod
     async def get_judge_prompt(self, task: TaskT, result: RolloutResult) -> str:
         """Format the prompt for the judge model."""
-        raise NotImplementedError("Subclasses must implement this method.")
+        raise NotImplementedError
 
     @abstractmethod
     async def get_reward(self, judgment: JudgmentFormat | str) -> float:
         """Get reward from judgment (structured or text)."""
-        raise NotImplementedError("Subclasses must implement this method.")
+        raise NotImplementedError
 
     async def get_judge_agent(self, task: TaskT, result: RolloutResult) -> Agent:
         """Build the agent that judges one sample. Override to configure it."""
-        # TODO: current model rotation is not within but across samples, amend this with a hook on AfterModelCallEvent if needed
+        # Rotation is across samples, not within one; a hook on AfterModelCallEvent would fix that.
         return Agent(
             model=next(self.judge_models),
             system_prompt=await self.get_system_prompt(task, result),

--- a/src/strands_env/core/mcp_tool.py
+++ b/src/strands_env/core/mcp_tool.py
@@ -13,9 +13,7 @@ if TYPE_CHECKING:
 class MCPToolAdapter(AgentTool):
     """Adapts an MCP tool to the Strands `AgentTool` interface.
 
-    Notes:
-        Subclasses must implement `call_tool()` to execute the tool call and
-        return parsed content and status.
+    Handles the tool-spec building; subclasses implement `call_tool()` for their transport.
     """
 
     def __init__(
@@ -30,12 +28,10 @@ class MCPToolAdapter(AgentTool):
 
     @property
     def tool_name(self) -> str:
-        """Return the tool name."""
         return self._mcp_tool.name
 
     @property
     def tool_spec(self) -> ToolSpec:
-        """Return the tool spec for the agent."""
         spec: ToolSpec = {
             "name": self._mcp_tool.name,
             "description": self._mcp_tool.description or self._mcp_tool.name,
@@ -47,21 +43,12 @@ class MCPToolAdapter(AgentTool):
 
     @property
     def tool_type(self) -> str:
-        """Return the tool type identifier."""
         return "python"
 
     async def call_tool(
         self, name: str, args: dict[str, Any]
     ) -> tuple[list[ToolResultContent], Literal["success", "error"]]:
-        """Execute the tool call and return parsed results. Override in subclasses.
-
-        Args:
-            name: The tool name.
-            args: The tool arguments.
-
-        Returns:
-            A tuple of (content, status).
-        """
+        """Execute the tool call and return parsed results. Override in subclasses."""
         raise NotImplementedError
 
     @override

--- a/src/strands_env/core/models.py
+++ b/src/strands_env/core/models.py
@@ -39,17 +39,7 @@ def sglang_model_factory(
     return_routed_experts: bool = False,
     enable_thinking: bool = True,
 ) -> ModelFactory:
-    """Return a factory that creates `SGLangModel` instances.
-
-    Args:
-        client: `SGLangClient` for HTTP communication with the SGLang server.
-        tokenizer: HuggingFace tokenizer for chat template and tokenization.
-        tool_parser: Tool parser for extracting tool calls from model output. Defaults to `HermesToolParser`.
-        sampling_params: Sampling parameters for the model (e.g. `{"max_new_tokens": 4096}`).
-        return_logprob: Whether to return logprobs for each token.
-        return_routed_experts: Whether to return MoE routed expert indices for routing replay.
-        enable_thinking: Enable thinking mode for models whose chat template supports it.
-    """
+    """Return a factory that creates `SGLangModel` instances."""
     if tool_parser is None:
         tool_parser = HermesToolParser()
 
@@ -116,18 +106,10 @@ def bedrock_model_factory(
 ) -> ModelFactory:
     """Return a factory that creates `BedrockModel` instances.
 
-    Args:
-        model_id: Bedrock model ID (e.g. `"us.anthropic.claude-sonnet-4-20250514-v1:0"`).
-        boto_session: Boto3 session for AWS credentials.
-        boto_client_config: Botocore client configuration.
-        sampling_params: Sampling parameters for the model (e.g. `{"max_new_tokens": 4096}`).
-
     Notes:
-        - A single boto3 client (thread-safe) is created once from the session and
-        shared across all model instances.  `BedrockModel` doesn't accept a pre-built client,
-        so we extract it from a pilot instance and override `model.client` on each subsequent one.
-        - The principle of operation is "one boto3 session, one boto3 client".
-        - `max_new_tokens` in `sampling_params` is remapped to `max_tokens` for the Bedrock API.
+        - One boto3 session, one boto3 client. The client is thread-safe, so it is built once and
+          shared; `BedrockModel` won't accept a pre-built one, hence the pilot instance below.
+        - `max_new_tokens` is remapped to `max_tokens` for the Bedrock API.
     """
     sampling_params = dict(sampling_params)
     if "max_new_tokens" in sampling_params:
@@ -165,12 +147,6 @@ def bedrock_mantle_model_factory(
     reasoning: dict[str, Any] | None = None,
 ) -> ModelFactory:
     """Return a factory that creates `OpenAIResponsesModel` for GPT models via Bedrock Mantle.
-
-    Args:
-        model_id: Bedrock Mantle model ID (e.g. `"openai.gpt-5.4-2026-03-05"`).
-        region: AWS region hosting Bedrock Mantle (default `"us-east-2"`).
-        sampling_params: Sampling parameters for the model (e.g. `{"max_new_tokens": 16384}`).
-        reasoning: Reasoning configuration (e.g. `{"effort": "high"}`).
 
     Notes:
         - Routing is delegated to the SDK's `bedrock_mantle_config`: it derives the regional
@@ -226,13 +202,8 @@ def openai_model_factory(
 ) -> ModelFactory:
     """Return a factory that creates `OpenAIModel` instances.
 
-    Args:
-        model_id: OpenAI model ID (e.g. `"gpt-4o"`).
-        sampling_params: Sampling parameters for the model (e.g. `{"max_new_tokens": 4096}`).
-        client_args: Arguments for the OpenAI client (e.g. `{"api_key": "...", "base_url": "..."}`).
-
     Notes:
-        `max_new_tokens` in `sampling_params` is remapped to `max_tokens` for the OpenAI API.
+        `max_new_tokens` is remapped to `max_tokens` for the OpenAI API.
     """
     sampling_params = dict(sampling_params)
     if "max_new_tokens" in sampling_params:
@@ -282,12 +253,8 @@ class ModelConfig:
 def build_model_factory(config: ModelConfig | dict[str, Any]) -> ModelFactory:
     """Build a `ModelFactory` from a `ModelConfig` or a serialized config dict.
 
-    This is the config-driven path for creating model factories, used by
-    eval hooks and Ray actors. For programmatic use with pre-built objects
-    (clients, tokenizers), use the individual factory functions directly.
-
-    Args:
-        config: Model configuration (dataclass or dict from `ModelConfig.to_dict()`).
+    For programmatic use with pre-built clients and tokenizers, call the individual factory
+    functions directly.
     """
     if isinstance(config, dict):
         config = ModelConfig(**config)

--- a/src/strands_env/core/types.py
+++ b/src/strands_env/core/types.py
@@ -38,7 +38,7 @@ class Task(BaseModel):
     )
 
 
-#: The task type an environment (or reward function) consumes. Defaults to `Task` (PEP 696),
+#: The task type an environment (or reward function) consumes. Defaults to `Task` (PEP 696).
 TaskT = TypeVar("TaskT", bound=Task, default=Task)
 
 
@@ -206,15 +206,10 @@ class RolloutResult(BaseModel):
 
 
 def extract_message_text(message: Message, *, raw: bool = False) -> str:
-    """Extract the final text from a message: the last text block.
+    """Extract the final text from a message: the last text block, `<think>` blocks stripped.
 
-    Args:
-        message: A strands Message dict.
-        raw: If True, return the full text including `<think>...</think>` blocks.
-            If False (default), strip think blocks before returning.
-
-    Returns an empty string when the message contains no text block.
-    An unclosed `<think>` block (truncated generation) is returned as-is.
+    Empty string when the message has no text block. An unclosed `<think>` block (truncated
+    generation) is returned as-is, since there is no closing tag to strip to.
     """
     content = message.get("content") or []
     text = next(

--- a/src/strands_env/environments/agentcore_code/env.py
+++ b/src/strands_env/environments/agentcore_code/env.py
@@ -25,9 +25,7 @@ class AgentCoreCodeConfig(EnvironmentConfig, total=False):
 class AgentCoreCodeEnv(Environment):
     """Code sandbox environment using AWS Bedrock AgentCore Code Interpreter.
 
-    Notes:
-        Provides `execute_code` (Python) and/or `execute_command` (shell) tools
-        depending on the configured mode.
+    `mode` decides which of `execute_code` (Python) and `execute_command` (shell) the agent gets.
     """
 
     default_system_prompt_path = Path(__file__).parent / "system_prompt.md"

--- a/src/strands_env/environments/agentcore_code/quotas.py
+++ b/src/strands_env/environments/agentcore_code/quotas.py
@@ -11,18 +11,16 @@ from aiolimiter import AsyncLimiter
 class CodeInterpreterQuotas:
     """Shared AWS quotas for Code Interpreter API operations.
 
-    Notes:
-        - Create one instance and pass it to all `CodeInterpreterToolkit` instances
-        to enforce account-wide limits across concurrent sessions.
-        - Manages three concerns:
-            - Session semaphore: caps concurrent sessions (`session_concurrency`).
-            - Rate limiters: caps API request initiation rate for start/invoke/stop
-              (AWS TPS quotas) to prevent throttling errors.
-            - Thread pool executor: sized to match `session_concurrency` so each session can
-              have one in-flight blocking boto3 call without starving others.
+    One instance passed to every `CodeInterpreterToolkit` is what enforces account-wide limits
+    across concurrent sessions. It holds three things:
 
-    References:
-        - [AWS Bedrock AgentCore default quotas](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/bedrock-agentcore-limits.html)
+    - a semaphore capping concurrent sessions at `session_concurrency`
+    - rate limiters on start/invoke/stop, so AWS TPS quotas produce waiting rather than throttling
+      errors
+    - a thread pool sized to `session_concurrency`, so every session can hold one blocking boto3
+      call in flight without starving the others
+
+    Defaults follow [AWS Bedrock AgentCore quotas](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/bedrock-agentcore-limits.html).
     """
 
     DEFAULT_SESSION_CONCURRENCY: ClassVar[int] = 1000
@@ -44,5 +42,5 @@ class CodeInterpreterQuotas:
         self.executor = ThreadPoolExecutor(max_workers=session_concurrency)
 
     def to_thread(self, func: Any, /, *args: Any, **kwargs: Any) -> Any:
-        """Run a blocking function in the quotas thread pool (or default pool if no quotas)."""
+        """Run a blocking function in the quotas thread pool."""
         return asyncio.get_running_loop().run_in_executor(self.executor, partial(func, *args, **kwargs))

--- a/src/strands_env/environments/agentcore_code/tool.py
+++ b/src/strands_env/environments/agentcore_code/tool.py
@@ -14,11 +14,11 @@ if TYPE_CHECKING:
 class CodeInterpreterToolkit:
     """Code toolkit using AWS Bedrock AgentCore Code Interpreter.
 
+    Exposes `execute_code` (Python) and `execute_command` (shell), both sandboxed.
+
     Notes:
-        - Provides `execute_code` and `execute_command` tools for running Python code
-          and shell commands in a sandboxed environment.
-        - One AgentCore session per toolkit, started lazily on the first call;
-          `cleanup` stops it.
+        One AgentCore session per toolkit, started lazily on the first call and stopped by
+        `cleanup`.
     """
 
     CODE_INTERPRETER_ID: ClassVar[str] = "aws.codeinterpreter.v1"

--- a/src/strands_env/environments/harbor/env.py
+++ b/src/strands_env/environments/harbor/env.py
@@ -26,12 +26,9 @@ if TYPE_CHECKING:
 class HarborConfig(EnvironmentConfig):
     """Serializable configuration for `HarborEnv`.
 
-    Backends:
-        - "docker": Local Docker via `harbor`'s native `DockerEnvironment`.
-        - "e2b": Self-hosted e2b sandbox (Firecracker microVM, e2b-on-AWS) via
-            `PrebakedE2BEnvironment`. Connection (`domain`/`api_key`) and template
-            config go in `prebaked_e2b_config`, or fall back to the
-            `E2B_DOMAIN` / `E2B_API_KEY` env vars.
+    `backend` picks between local Docker (harbor's native `DockerEnvironment`) and a self-hosted
+    e2b sandbox (Firecracker microVM) via `PrebakedE2BEnvironment`. For e2b, connection and
+    template settings go in `prebaked_e2b_config`, falling back to `E2B_DOMAIN` / `E2B_API_KEY`.
     """
 
     exec_timeout: NotRequired[int]  # sandbox.exec timeout; also the verifier fallback
@@ -122,7 +119,6 @@ class HarborEnv(Environment[HarborTask]):
 
     @override
     def get_tools(self) -> list:
-        """Return the execute_command tool."""
         return [self.execute_command]
 
     @override

--- a/src/strands_env/environments/harbor/reward.py
+++ b/src/strands_env/environments/harbor/reward.py
@@ -25,7 +25,6 @@ class HarborReward(RewardFunction["HarborTask"]):
         self._env = env
 
     async def compute(self, task: HarborTask, result: RolloutResult) -> RewardResult:
-        """Run harbor's Verifier in the sandbox and return its reward."""
         try:
             assert self._env.sandbox is not None, "sandbox not initialized"
             timeout = task.verifier_timeout if task.verifier_timeout is not None else self._env.exec_timeout

--- a/src/strands_env/environments/math/reward.py
+++ b/src/strands_env/environments/math/reward.py
@@ -22,17 +22,15 @@ _EXTRACTION_CONFIG = (LatexExtractionConfig(), ExprExtractionConfig())
 class MathVerifyReward(RewardFunction):
     r"""Reward 1.0 if the model's `\boxed{}` answer is mathematically equivalent to ground truth.
 
+    `math_verify.parse` converts both sides to SymPy and `math_verify.verify` compares them, which
+    is what handles fraction/decimal equivalence, symbolic simplification, sets and intervals, and
+    LaTeX normalization. When either side parses to several candidates — several `\boxed{}` in one
+    response — a match on any gold-target pair counts.
+
     Notes:
-        - Uses `math_verify.parse` to extract and convert answers to SymPy,
-          then `math_verify.verify` for equivalence checking. This handles
-          fraction/decimal equivalence, symbolic simplification, sets/intervals,
-          and nested expressions with LaTeX normalization.
-        - When either side parses to multiple candidate expressions (e.g. several
-          `\\boxed{}` in the response), `verify` returns True if **any**
-          gold-target pair matches (Cartesian product).
-        - Uses `with_timeout` decorator for thread-safe timeouts. Math-verify's
-          built-in timeout uses signal.alarm() which only works in the main thread.
-          See: https://github.com/huggingface/Math-Verify/issues/42
+        Timeouts go through `with_timeout` rather than math-verify's own, which uses
+        `signal.alarm()` and so only fires on the main thread.
+        See https://github.com/huggingface/Math-Verify/issues/42.
     """
 
     def __init__(
@@ -82,7 +80,7 @@ class MathVerifyReward(RewardFunction):
                 gold=gold,
                 target=answer,
                 float_rounding=self.float_rounding,
-                timeout_seconds=None,  # Disable math-verify's timeout, use manual timeout
+                timeout_seconds=None,  # see `parse_expression`
             )
 
         return _verify()

--- a/src/strands_env/environments/mcp_atlas/env.py
+++ b/src/strands_env/environments/mcp_atlas/env.py
@@ -26,12 +26,13 @@ class MCPAtlasConfig(EnvironmentConfig):
 class MCPAtlasEnv(Environment[MCPAtlasTask]):
     """MCP-Atlas benchmark environment backed by a Docker container.
 
+    `reset()` fetches the container's tool list and keeps only what the task's `enabled_tools`
+    names — a strict filter, so an empty one enables nothing. `cleanup()` drops that list and
+    leaves the HTTP client alone.
+
     Notes:
-        - A shared `httpx.AsyncClient` is passed in at construction time;
-          the caller owns its lifecycle (create once, close after all tasks).
-        - `reset()` fetches tools from the container and applies the task's
-          `enabled_tools` filter strictly (an empty filter enables no tools).
-        - `cleanup()` clears the tool list only.
+        The `httpx.AsyncClient` is caller-owned: create it once (see `create_client`), pass it to
+        every env, and close it after all tasks. Nothing here closes it.
     """
 
     DEFAULT_DOCKER_URL: ClassVar[str] = "http://localhost:1984"
@@ -50,13 +51,12 @@ class MCPAtlasEnv(Environment[MCPAtlasTask]):
         """Initialize an `MCPAtlasEnv` instance.
 
         Args:
-            model_factory: Factory for the agent's model.
-            http_client: Shared client for the MCP-Atlas container (see `create_client`);
-                the caller owns its lifecycle.
-            reward_fn: Optional reward function (None = inference-only).
-            cached_tools: Pre-fetched `/list-tools` response; skips the fetch in `reset()`.
-                Share one across envs to avoid refetching per episode.
-            **config: See `MCPAtlasConfig`.
+            model_factory: builds the agent's model.
+            http_client: shared client for the container; caller-owned.
+            reward_fn: `None` means inference-only, no scoring.
+            cached_tools: a pre-fetched `/list-tools` response, which skips the fetch in `reset()`.
+                Share one across envs so the list isn't refetched per episode.
+            **config: see `MCPAtlasConfig`.
         """
         super().__init__(
             model_factory=model_factory,
@@ -77,8 +77,7 @@ class MCPAtlasEnv(Environment[MCPAtlasTask]):
     ) -> httpx.AsyncClient:
         """Create an `httpx.AsyncClient` configured for the MCP-Atlas container.
 
-        The caller owns the returned client's lifecycle and should close it
-        when done (e.g. via `async with` or explicit `aclose()`).
+        Caller-owned: close it with `async with` or an explicit `aclose()` once every task is done.
         """
         limits = httpx.Limits(
             max_connections=max_connections,

--- a/src/strands_env/environments/mcp_atlas/reward.py
+++ b/src/strands_env/environments/mcp_atlas/reward.py
@@ -70,9 +70,8 @@ class ClaimJudgment(BaseModel):
 class MCPAtlasReward(LLMJudgeReward[ClaimJudgment, MCPAtlasTask]):
     """Per-claim LLM-as-judge reward for MCP-Atlas benchmark.
 
-    Overrides `compute()` to judge each GTFA claim individually (one
-    `super().compute()` call per claim) and aggregate the mean coverage
-    score into a binary reward at the 0.75 pass threshold.
+    `compute()` judges each GTFA claim on its own — one `super().compute()` call per claim — then
+    binarizes the mean coverage score at `PASS_THRESHOLD`.
     """
 
     judgment_format = ClaimJudgment
@@ -91,7 +90,7 @@ class MCPAtlasReward(LLMJudgeReward[ClaimJudgment, MCPAtlasTask]):
 
     @override
     async def compute(self, task: MCPAtlasTask, result: RolloutResult) -> RewardResult:
-        """Judge every claim, then binarize the mean coverage at the 0.75 threshold."""
+        """Judge every claim, then binarize the mean coverage at `PASS_THRESHOLD`."""
         claims: list[str] = task.gtfa_claims
 
         if not claims:

--- a/src/strands_env/environments/tau2_bench/env.py
+++ b/src/strands_env/environments/tau2_bench/env.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, NotRequired, Unpack, override
+from typing import NotRequired, Unpack, override
 
 from strands.types.content import Message
 from strands_sglang import LoopLimiter
@@ -14,9 +14,6 @@ from .reward import Tau2BenchReward
 from .simulator import Tau2BenchTerminationReason, Tau2BenchUserSimulator
 from .task import Tau2BenchTask
 from .tool import Tau2BenchTool
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -113,8 +110,7 @@ class Tau2BenchEnv(Environment[Tau2BenchTask]):
         if self.user_simulator.termination is Tau2BenchTerminationReason.USER_STOP:
             result = RolloutResult(
                 messages=[{"role": "user", "content": [{"text": task.message}]}],
-                # A fresh limiter reports the truth: the agent loop processed nothing
-                # `agent=None`: the user stopped at the greeting, no assistant agent ever ran
+                # No assistant agent ran, so both a null agent and a fresh limiter report zeroes.
                 metrics=self.compute_metrics(None, LoopLimiter()),
                 termination_reason=TerminationReason.TASK_COMPLETE,
             )
@@ -132,7 +128,6 @@ class Tau2BenchEnv(Environment[Tau2BenchTask]):
 
     @override
     def get_tools(self) -> list:
-        """Return the agent-side tools."""
         return list(self.agent_tools)
 
     @override

--- a/src/strands_env/environments/tau2_bench/simulator.py
+++ b/src/strands_env/environments/tau2_bench/simulator.py
@@ -23,9 +23,8 @@ logger = logging.getLogger(__name__)
 class Tau2BenchTerminationReason(StrEnum):
     """Why the tau2 dialogue ended, in tau2's own vocabulary.
 
-    Notes:
-        Matching tau2's dual mode, only the user can end the dialogue — the standard
-        tau2 `LLMAgent` never overrides `is_stop`, so there is no agent-side stop.
+    There is no agent-side stop: matching tau2's dual mode, only the user ends the dialogue, and
+    tau2's own `LLMAgent` never overrides `is_stop`.
     """
 
     USER_STOP = "user_stop"
@@ -94,12 +93,9 @@ class Tau2BenchUserSimulator(HookProvider):
         return text
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
-        """Subscribe to `AfterInvocationEvent`."""
         registry.add_callback(AfterInvocationEvent, self._on_after_invocation)
 
     async def _on_after_invocation(self, event: AfterInvocationEvent) -> None:
-
-        # Extract the agent's response text (no think block)
         agent_text = extract_message_text(event.result.message) if event.result else ""
 
         # Re-arm the shared step budget: on top of what the user-sim has already consumed,
@@ -109,7 +105,6 @@ class Tau2BenchUserSimulator(HookProvider):
             user_result = await self.agent.invoke_async(agent_text)
             user_text = extract_message_text(user_result.message)
         except Exception as e:
-            # Check if the error is caused by the max steps limit
             if TerminationReason.from_error(e) is TerminationReason.MAX_MESSAGES_REACHED:
                 self.termination = Tau2BenchTerminationReason.MAX_STEPS
                 return
@@ -117,12 +112,10 @@ class Tau2BenchUserSimulator(HookProvider):
             self.termination = Tau2BenchTerminationReason.ABORTED
             return
 
-        # Check if the user wanted to stop the dialogue
         if self.STOP_PATTERN.search(user_text):
             self.termination = Tau2BenchTerminationReason.USER_STOP
             # Append the terminating user msg so it shows up in `result.messages`.
             event.agent.messages.append({"role": "user", "content": [{"text": user_text}]})
             return
 
-        # Resume the assistant conversation with simulated user response
         event.resume = user_text

--- a/src/strands_env/environments/tau2_bench/task.py
+++ b/src/strands_env/environments/tau2_bench/task.py
@@ -25,7 +25,6 @@ class Tau2BenchTask(Task):
 
     @cached_property
     def tau2_task(self) -> Tau2Task:
-        """Parsed tau2 task."""
         return _tau2.Tau2Task.model_validate(self.config)
 
     @cached_property

--- a/src/strands_env/environments/tau2_bench/tool.py
+++ b/src/strands_env/environments/tau2_bench/tool.py
@@ -25,7 +25,6 @@ class Tau2BenchTool(AgentTool):
 
     @property
     def tool_name(self) -> str:
-        """Return the tau2 tool name."""
         return self._tool.name
 
     @property
@@ -42,7 +41,6 @@ class Tau2BenchTool(AgentTool):
 
     @property
     def tool_type(self) -> str:
-        """Strands tool type identifier."""
         return "python"
 
     @override

--- a/src/strands_env/environments/web_search/env.py
+++ b/src/strands_env/environments/web_search/env.py
@@ -79,8 +79,13 @@ class WebSearchEnv(Environment):
             return [self.search_tool, self.scrape_tool]
         return [self.search_tool]
 
+    @override
     async def cleanup(self) -> None:
-        """Close the toolkits' shared HTTP sessions — once, after all rollouts."""
+        """Close the toolkits' HTTP sessions.
+
+        `rollout()` calls this after every episode, so the sessions do not survive across rollouts;
+        `_get_session` reopens a closed one on the next call.
+        """
         await self.search_toolkit.cleanup()
         if self.scraper_toolkit is not None:
             await self.scraper_toolkit.cleanup()

--- a/src/strands_env/environments/web_search/tools/scrape.py
+++ b/src/strands_env/environments/web_search/tools/scrape.py
@@ -63,11 +63,11 @@ class WebPageSummary(BaseModel):
 class WebScraperToolkit:
     """Web scraper with LLM-based structured summarization.
 
+    With a `summarizer_model_factory`, fetched pages go through an LLM that extracts evidence and a
+    summary for the caller's goal; without one, `scrape` returns the raw page.
+
     Notes:
-        - When a `summarizer_model_factory` is set, runs an LLM to produce structured
-          output for the supplied goal based on fetched webpage content.
-        - A single shared `aiohttp.ClientSession` (created lazily) and an
-          `asyncio.Semaphore` cap concurrent requests. Call `cleanup` when done.
+        Holds one lazily-created `aiohttp.ClientSession`; `cleanup` closes it.
     """
 
     def __init__(
@@ -92,13 +92,12 @@ class WebScraperToolkit:
         self._session: aiohttp.ClientSession | None = None
 
     def _get_session(self) -> aiohttp.ClientSession:
-        """Get or create the shared HTTP session."""
+        # Reopened if closed, so a cleaned-up toolkit still works if reused.
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=self.timeout))
         return self._session
 
     async def cleanup(self) -> None:
-        """Close the shared HTTP session."""
         if self._session and not self._session.closed:
             await self._session.close()
             self._session = None
@@ -117,9 +116,7 @@ class WebScraperToolkit:
         max_retries: int = 8,
         retry_delay: float = 0.5,
     ) -> str:
-        """Fetch a URL and return the response text, retrying on transient errors.
-
-        Retries on exceptions and empty response bodies.
+        """Fetch a URL and return the response text, retrying on exceptions and empty bodies.
 
         Args:
             url: The URL to fetch. Callers may pass a provider-wrapped URL (e.g. `https://r.jina.ai/{target}`) directly.

--- a/src/strands_env/environments/web_search/tools/search.py
+++ b/src/strands_env/environments/web_search/tools/search.py
@@ -25,11 +25,12 @@ type WebSearchAPIProvider = Literal["serper", "google"]
 class WebSearchToolkit:
     """Search tools behind a provider switch (`serper` / `google`).
 
+    Each provider is a separate `@tool` method, so an environment can expose one, the other, or
+    the unified `search` that dispatches on `api_provider`. Credentials are checked lazily by
+    `@requires_env`, at call time rather than construction.
+
     Notes:
-        - Each provider is exposed as a separate `@tool` method so the environment
-          can pick which one to use. Credentials are validated lazily via `@requires_env`.
-        - A single shared `aiohttp.ClientSession` (created lazily) and an
-          `asyncio.Semaphore` cap concurrent requests. Call `cleanup` when done.
+        Holds one lazily-created `aiohttp.ClientSession`; `cleanup` closes it.
     """
 
     def __init__(
@@ -54,13 +55,12 @@ class WebSearchToolkit:
         self._session: aiohttp.ClientSession | None = None
 
     def _get_session(self) -> aiohttp.ClientSession:
-        """Get or create the shared HTTP session."""
+        # Reopened if closed, so a cleaned-up toolkit still works if reused.
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=self.timeout))
         return self._session
 
     async def cleanup(self) -> None:
-        """Close the shared HTTP session."""
         if self._session and not self._session.closed:
             await self._session.close()
             self._session = None
@@ -78,8 +78,7 @@ class WebSearchToolkit:
     ) -> str:
         """Format a list of search result dicts into a numbered text block.
 
-        Notes:
-            Hook method — override in subclasses to customize formatting.
+        A hook: override to change how results reach the model.
         """
         if not items:
             return "No results found."

--- a/src/strands_env/eval/benchmarks/aime.py
+++ b/src/strands_env/eval/benchmarks/aime.py
@@ -19,11 +19,7 @@ class AIMEEvaluator(Evaluator):
 
     @override
     def load_dataset(self) -> Iterable[Task]:
-        """Load AIME dataset from HuggingFace (streaming).
-
-        Yields:
-            Task objects with problem text and ground truth.
-        """
+        """Load AIME dataset from HuggingFace (streaming)."""
         dataset = load_dataset(self.hf_dataset_path, split="train", streaming=True)
 
         for i, row in enumerate(dataset):

--- a/src/strands_env/eval/benchmarks/browsecomp.py
+++ b/src/strands_env/eval/benchmarks/browsecomp.py
@@ -59,7 +59,6 @@ class BrowseCompReward(LLMJudgeReward[BrowseCompJudgment]):
 
     @override
     async def get_judge_prompt(self, task: Task, result: RolloutResult) -> str:
-        """Get judge prompt for BrowseComp benchmark."""
         return GRADER_TEMPLATE.format(
             query=task.message,
             ground_truth=task.ground_truth,
@@ -68,7 +67,6 @@ class BrowseCompReward(LLMJudgeReward[BrowseCompJudgment]):
 
     @override
     async def get_reward(self, judgment: BrowseCompJudgment | str) -> float:
-        """Get reward for BrowseComp benchmark."""
         if isinstance(judgment, BrowseCompJudgment):
             return {"yes": 1.0, "no": 0.0}[judgment.correct]
         return self.default_reward
@@ -87,10 +85,7 @@ class BrowseCompEvaluator(Evaluator):
     def load_dataset(self) -> Iterable[Task]:
         """Load BrowseComp dataset from OpenAI's public CSV.
 
-        Problems and answers are XOR-encrypted; decrypted here using the canary column.
-
-        Yields:
-            Task objects with decrypted question and ground truth answer.
+        Problems and answers are XOR-encrypted; decrypted here using each row's canary column.
         """
         df = pd.read_csv(DATASET_URL)
 

--- a/src/strands_env/eval/benchmarks/frames.py
+++ b/src/strands_env/eval/benchmarks/frames.py
@@ -52,7 +52,6 @@ class FramesReward(LLMJudgeReward[FramesJudgment]):
 
     @override
     async def get_judge_prompt(self, task: Task, result: RolloutResult) -> str:
-        """Get judge prompt for FRAMES benchmark."""
         return GRADER_TEMPLATE.format(
             query=task.message,
             ground_truth=task.ground_truth,
@@ -61,7 +60,6 @@ class FramesReward(LLMJudgeReward[FramesJudgment]):
 
     @override
     async def get_reward(self, judgment: FramesJudgment | str) -> float:
-        """Get reward for FRAMES benchmark."""
         if isinstance(judgment, FramesJudgment):
             return {"TRUE": 1.0, "FALSE": 0.0}[judgment.decision]
         return self.default_reward
@@ -75,11 +73,7 @@ class FramesEvaluator(Evaluator):
 
     @override
     def load_dataset(self) -> Iterable[Task]:
-        """Load FRAMES benchmark dataset from HuggingFace.
-
-        Yields:
-            Task objects with question, wiki links in task context, and ground truth.
-        """
+        """Load FRAMES benchmark dataset from HuggingFace."""
         dataset = load_dataset(self.hf_dataset_path, split="test")
 
         for i, row in enumerate(dataset):

--- a/src/strands_env/eval/benchmarks/gpqa.py
+++ b/src/strands_env/eval/benchmarks/gpqa.py
@@ -39,7 +39,7 @@ class GPQAReward(RewardFunction):
     """
 
     #: Primary regex — matches `(A)` through `(Z)` with parentheses (case-sensitive,
-    #: matching lm-evaluation-harness where ``ignore_case`` only applies to choice text).
+    #: matching lm-evaluation-harness, where `ignore_case` only applies to choice text).
     PRIMARY_PATTERN: ClassVar[re.Pattern[str]] = re.compile(r"\(([A-Z])\)")
 
     #: Fallback regex — bare letter after a colon, e.g. `Answer: B`.
@@ -107,9 +107,8 @@ class GPQAEvaluator(Evaluator):
     """Base evaluator for GPQA benchmarks.
 
     Loads the `Idavidrein/gpqa` dataset (gated; requires HuggingFace login and
-    dataset access). Choice text is cleaned with the same ``preprocess``
-    function used by lm-evaluation-harness, and choices are shuffled with a
-    per-sample deterministic seed for reproducibility.
+    dataset access). Choice text is cleaned with the same `preprocess` function
+    lm-evaluation-harness uses, and choices are shuffled with a per-sample deterministic seed.
     """
 
     hf_dataset_path = "Idavidrein/gpqa"
@@ -118,7 +117,7 @@ class GPQAEvaluator(Evaluator):
 
     @staticmethod
     def preprocess(text: str | None) -> str:
-        """Clean choice text, matching lm-evaluation-harness ``process_docs``."""
+        """Clean choice text, matching lm-evaluation-harness `process_docs`."""
         if text is None:
             return " "
         text = text.strip()
@@ -131,13 +130,9 @@ class GPQAEvaluator(Evaluator):
     def load_dataset(self) -> Iterable[Task]:
         """Load GPQA dataset from HuggingFace (streaming).
 
-        Answer choices are preprocessed (matching lm-evaluation-harness) and
-        shuffled with a per-sample deterministic seed for reproducibility. Each
-        task message contains the question followed by four labeled answer
-        choices (A)-(D).
-
-        Yields:
-            Task objects with formatted multiple-choice question and ground truth.
+        Choices are preprocessed to match lm-evaluation-harness, then shuffled with a per-sample
+        deterministic seed so a rerun grades the same letters. Each message holds the question
+        followed by the four labelled choices (A)-(D).
         """
         try:
             dataset = load_dataset(self.hf_dataset_path, self.hf_dataset_config, split="train", streaming=True)

--- a/src/strands_env/eval/benchmarks/hle_verified.py
+++ b/src/strands_env/eval/benchmarks/hle_verified.py
@@ -74,7 +74,6 @@ class HLEReward(LLMJudgeReward[HLEJudgment]):
 
     @override
     async def get_judge_prompt(self, task: Task, result: RolloutResult) -> str:
-        """Get judge prompt for HLE-Verified benchmark."""
         return GRADER_TEMPLATE.format(
             query=task.message,
             ground_truth=task.ground_truth,
@@ -83,7 +82,6 @@ class HLEReward(LLMJudgeReward[HLEJudgment]):
 
     @override
     async def get_reward(self, judgment: HLEJudgment | str) -> float:
-        """Get reward for HLE-Verified benchmark."""
         if isinstance(judgment, HLEJudgment):
             return {"yes": 1.0, "no": 0.0}[judgment.correct]
         return self.default_reward
@@ -133,11 +131,8 @@ class HLEVerifiedEvaluator(Evaluator):
     def load_dataset(self) -> Iterable[Task]:
         """Load the HLE-Verified Gold subset from HuggingFace (streaming).
 
-        Yields:
-            Task objects with question text and ground-truth answer. When a
-            sample has an inline image, the task message is a multimodal
-            `Message` (text + image content block). When `text_only` is set,
-            samples whose nested `json.image` field is non-empty are skipped.
+        A sample carrying an inline image yields a multimodal `Message` (text plus an image content
+        block) rather than a plain string; with `text_only` set, those samples are skipped instead.
         """
         dataset = load_dataset(self.hf_dataset_path, split="train", streaming=True)
 

--- a/src/strands_env/eval/benchmarks/hmmt.py
+++ b/src/strands_env/eval/benchmarks/hmmt.py
@@ -19,11 +19,7 @@ class HMMTEvaluator(Evaluator):
 
     @override
     def load_dataset(self) -> Iterable[Task]:
-        """Load HMMT dataset from HuggingFace (streaming).
-
-        Yields:
-            Task objects with problem text and ground truth.
-        """
+        """Load HMMT dataset from HuggingFace (streaming)."""
         dataset = load_dataset(self.hf_dataset_path, split="train", streaming=True)
 
         for i, row in enumerate(dataset):

--- a/src/strands_env/eval/benchmarks/mcp_atlas.py
+++ b/src/strands_env/eval/benchmarks/mcp_atlas.py
@@ -54,14 +54,7 @@ class MCPAtlasEvaluator(Evaluator[MCPAtlasTask]):
         available_servers: frozenset[str] | None = DEFAULT_SERVERS,
         **kwargs: object,
     ):
-        """Initialize a `MCPAtlasEvaluator` instance.
-
-        Args:
-            env_factory: Async factory that creates a fresh `MCPAtlasEnv` per sample.
-            available_servers: Servers available in the container. Tasks requiring
-                servers outside this set are skipped. None disables filtering.
-            **kwargs: Forwarded to `Evaluator.__init__`.
-        """
+        """A task needing a server outside `available_servers` is skipped; `None` keeps them all."""
         super().__init__(env_factory=env_factory, **kwargs)  # type: ignore[arg-type]
         self._available_servers = available_servers
 

--- a/src/strands_env/eval/benchmarks/sealqa.py
+++ b/src/strands_env/eval/benchmarks/sealqa.py
@@ -29,11 +29,7 @@ class SealQAEvaluator(Evaluator):
 
     @override
     def load_dataset(self) -> Iterable[Task]:
-        """Load SealQA dataset from HuggingFace.
-
-        Yields:
-            Task objects with question text, ground truth, and task metadata.
-        """
+        """Load SealQA dataset from HuggingFace (streaming)."""
         dataset = load_dataset(self.hf_dataset_path, name=self.hf_dataset_config, split="test", streaming=True)
 
         for i, row in enumerate(dataset):

--- a/src/strands_env/eval/benchmarks/simpleqa_verified.py
+++ b/src/strands_env/eval/benchmarks/simpleqa_verified.py
@@ -111,7 +111,6 @@ class SimpleQAReward(LLMJudgeReward[SimpleQAJudgment]):
 
     @override
     async def get_judge_prompt(self, task: Task, result: RolloutResult) -> str:
-        """Get judge prompt for SimpleQA-Verified benchmarks."""
         return GRADER_TEMPLATE.format(
             query=task.message,
             ground_truth=task.ground_truth,
@@ -120,7 +119,6 @@ class SimpleQAReward(LLMJudgeReward[SimpleQAJudgment]):
 
     @override
     async def get_reward(self, judgment: SimpleQAJudgment | str) -> float:
-        """Get reward for SimpleQA-Verified benchmarks."""
         if isinstance(judgment, SimpleQAJudgment):
             return {"CORRECT": 1.0, "INCORRECT": 0.0, "NOT_ATTEMPTED": 0.0}[judgment.grade]
         return self.default_reward
@@ -134,11 +132,7 @@ class SimpleQAVerifiedEvaluator(Evaluator):
 
     @override
     def load_dataset(self) -> Iterable[Task]:
-        """Load SimpleQA-Verified dataset from HuggingFace (streaming).
-
-        Yields:
-            Task objects with problem text and ground truth.
-        """
+        """Load SimpleQA-Verified dataset from HuggingFace (streaming)."""
         dataset = load_dataset(self.hf_dataset_path, split="eval", streaming=True)
 
         for i, row in enumerate(dataset):

--- a/src/strands_env/eval/benchmarks/swebench.py
+++ b/src/strands_env/eval/benchmarks/swebench.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 from typing import override
 
-from strands_env.environments.harbor import SWE_SYSTEM_PROMPT_PATH, HarborTask
+from strands_env.environments.harbor import SWE_SYSTEM_PROMPT_PATH
 
 from ..registry import register_eval
 from .terminal_bench import TerminalBenchEvaluator
@@ -82,11 +82,3 @@ class SWEBenchVerifiedEvaluator(TerminalBenchEvaluator):
             shutil.rmtree(repo_dir)
         except OSError:
             pass
-
-    @override
-    def load_dataset(self) -> list[HarborTask]:
-        """Load swebench-verified Harbor tasks (one Task per task directory)."""
-        # Same as the parent, but be explicit about the README/LICENSE filter:
-        # the swebench-verified dir contains task subdirs only after the
-        # sparse checkout, so the parent's "skip dotfiles" rule is enough.
-        return super().load_dataset()

--- a/src/strands_env/eval/benchmarks/tau2_bench.py
+++ b/src/strands_env/eval/benchmarks/tau2_bench.py
@@ -83,7 +83,7 @@ class Tau2BenchEvaluator(Evaluator[Tau2BenchTask]):
 
     @override
     def get_metric_fns(self) -> list[MetricFunction]:
-        """Report both ``pass@k`` (at-least-one) and ``pass^k`` (consistency, tau2 paper)."""
+        """Report both `pass@k` (at-least-one) and `pass^k` (consistency, per the tau2 paper)."""
         k_values = list(range(1, self.n_samples_per_prompt + 1))
         return [
             partial(compute_pass_at_k, k_values=k_values, reward_threshold=1.0),

--- a/src/strands_env/eval/cli.py
+++ b/src/strands_env/eval/cli.py
@@ -27,7 +27,6 @@ class JsonType(click.ParamType):
     name = "JSON"
 
     def convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> dict:
-        """Convert value to dict."""
         path = Path(value)
         if path.is_file():
             with open(path, encoding="utf-8") as f:
@@ -178,8 +177,8 @@ def eval_cmd(
 ) -> None:
     """Run a benchmark evaluation.
 
-    Select what to run with --benchmark (a registered benchmark name) or
-    --evaluator (a custom evaluator module exporting EvaluatorClass). Use --list
+    Select what to run with --benchmark (a registered benchmark name) or --evaluator (a custom
+    evaluator module exporting EvaluatorClass); --benchmark wins if both are given. Use --list
     to see the registered benchmarks.
 
     Examples:
@@ -194,7 +193,6 @@ def eval_cmd(
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
-    # Resolve evaluator; --benchmark takes precedence over --evaluator
     if benchmark:
         evaluator_cls = get_benchmark(benchmark)
         benchmark_name = benchmark
@@ -205,10 +203,9 @@ def eval_cmd(
         evaluator_cls = load_evaluator_hook(evaluator_path)
         benchmark_name = evaluator_cls.benchmark_name
 
-    # Load env factory hook (validate before building model)
+    # Fail on a bad hook path before spending time building the model.
     load_env_factory_hook(env_hook)
 
-    # Build model config
     sampling_params: dict = {"max_new_tokens": max_tokens}
     if temperature is not None:
         sampling_params["temperature"] = temperature
@@ -250,11 +247,9 @@ def eval_cmd(
         env_factory_creator = load_env_factory_hook(env_hook)
         env_factory = env_factory_creator(model_config.to_dict(), **(env_config or {}))
 
-    # Output paths
     output_dir = output or Path(f"{benchmark_name}_eval")
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create evaluator and load dataset
     evaluator = evaluator_cls(
         env_factory=env_factory,
         max_concurrency=max_concurrency,
@@ -285,7 +280,6 @@ def eval_cmd(
         "mode": mode,
     }
 
-    # Run, compute metrics, and publish through the reporter
     async def _run_eval() -> None:
         evaluator.reporter.log_metadata(metadata)
         results = await evaluator.run(tasks)

--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -37,7 +37,6 @@ class EvalSample(BaseModel, Generic[TaskT]):
 class Evaluator(Generic[TaskT]):
     """Evaluator for running concurrent environment evaluations."""
 
-    # Basic benchmark identity variables.
     benchmark_name: ClassVar[str] = ""
     hf_dataset_path: ClassVar[str] = ""  # HuggingFace dataset id, if any
     hf_dataset_config: ClassVar[str] = ""  # HF config/subset within the dataset, if any
@@ -59,15 +58,17 @@ class Evaluator(Generic[TaskT]):
         """Initialize an `Evaluator` instance.
 
         Args:
-            env_factory: Async factory function that creates a fresh Environment per sample.
-                Required for local evaluation; unused when `env_actor_pool` is provided.
-            max_concurrency: Maximum concurrent evaluate_sample() calls.
-            n_samples_per_prompt: Number of samples per prompt (for pass@k, set to max(k_values)).
-            output_path: Path to JSONL file for saving results. Enables resume.
-            save_interval: Flush results to disk every N completed samples.
-            keep_rollout: Keep the token-level rollout in results (only valid for `SGLangModel` backends).
-            env_actor_pool: Optional Ray actor pool for distributed evaluation.
-            reporter: Optional reporter for result output. Defaults to LocalReporter writing to output_path.
+            env_factory: builds a fresh Environment per sample. Required locally, ignored when
+                `env_actor_pool` is given.
+            max_concurrency: ceiling on concurrent `evaluate_sample()` calls.
+            n_samples_per_prompt: samples per prompt; for pass@k set it to `max(k_values)`.
+            output_path: JSONL destination, and what makes resume possible — an existing file is
+                read back and its completed samples skipped.
+            save_interval: flush every N completed samples.
+            keep_rollout: keep the token-level rollout in results. SGLang backends only; the others
+                produce an empty one.
+            env_actor_pool: Ray actor pool for distributed evaluation.
+            reporter: result sink; defaults to a `LocalReporter` on `output_path`.
         """
         if env_factory is None and env_actor_pool is None:
             raise ValueError("Must provide either env_factory or env_actor_pool")
@@ -81,10 +82,8 @@ class Evaluator(Generic[TaskT]):
         self.save_interval = save_interval
         self.keep_rollout = keep_rollout
 
-        # Reporter setup: explicit reporter wins; otherwise default to LocalReporter
         self.reporter: EvalReporter = reporter if reporter is not None else LocalReporter(self.output_path)
 
-        # Runtime state
         self.results: dict[str, list[EvalSample[TaskT]]] = defaultdict(list)
         self.completed_ids: set[str] = set()
 
@@ -99,12 +98,11 @@ class Evaluator(Generic[TaskT]):
     def validate_sample(self, sample: EvalSample[TaskT]) -> bool:
         """Check if a completed sample is valid. Override with benchmark-specific logic.
 
-        Notes:
-            - Return `True` to mark the sample as valid, `False` to mark it as aborted (excluded from metrics, retried on resume).
-            - By default a sample is invalid unless it carries a reward that computed: a
-              missing reward, or one whose `info` says `status: "error"`, cannot be scored,
-              and metrics count an unscorable sample as *incorrect* rather than absent.
-              Keeping it would report a fabricated number.
+        `False` marks the sample aborted: excluded from metrics, retried on resume.
+
+        The default rejects anything without a reward that computed — a missing `reward_result`, or
+        one whose `info` says `status: "error"`. Metrics count an unscorable sample as *incorrect*
+        rather than absent, so keeping it would report a fabricated number.
         """
         reward_result = sample.result.reward_result
         return reward_result is not None and reward_result.info.get("status") != "error"
@@ -112,8 +110,7 @@ class Evaluator(Generic[TaskT]):
     def get_metric_fns(self) -> list[MetricFunction]:
         """Return metric functions for evaluation. Override to customize.
 
-        Notes:
-            By default, includes pass@k metric based on `n_samples_per_prompt`.
+        Defaults to pass@k for every k up to `n_samples_per_prompt`.
         """
         return [
             partial(
@@ -154,17 +151,15 @@ class Evaluator(Generic[TaskT]):
     async def evaluate_sample(self, task: TaskT) -> EvalSample[TaskT]:
         """Evaluate a single sample."""
         try:
-            # Run evaluation in distributed or local mode
             if self.env_actor_pool is not None:
                 result = await self.env_actor_pool.rollout(task)
             else:
                 assert self.env_factory is not None
                 env = await self.env_factory()
                 result = await env.rollout(task)
-            # Clean up the token-level rollout if not needed to reduce verbosity
+            # Dropped by default: a full token trajectory per sample bloats results.jsonl.
             if not self.keep_rollout:
                 result.rollout = None
-            # Runtime logging for debugging
             reward_str = f"{result.reward_result.reward:.2f}" if result.reward_result else "N/A"
             reward_info = result.reward_result.info if result.reward_result else {}
             logger.info(
@@ -176,7 +171,6 @@ class Evaluator(Generic[TaskT]):
                 reward_info,
                 result.metrics,
             )
-            # Return the evaluation sample with aborted flag set
             sample = EvalSample(task=task, result=result)
             sample.aborted = not self.validate_sample(sample)
             if sample.aborted:
@@ -241,10 +235,8 @@ class Evaluator(Generic[TaskT]):
     def compute_metrics(self, results: dict[str, list[EvalSample]], log: bool = True) -> dict[str, float]:
         """Compute all metrics on results.
 
-        Notes:
-            Aborted samples are excluded from metric computation.
+        One aborted sample excludes its whole prompt, which keeps n consistent for pass@k.
         """
-        # Exclude entire prompt if any sample is aborted (keeps n consistent for pass@k)
         filtered = {pid: samples for pid, samples in results.items() if not any(s.aborted for s in samples)}
 
         metrics = {}
@@ -257,7 +249,6 @@ class Evaluator(Generic[TaskT]):
             n_samples = sum(len(s) for s in filtered.values())
             name = self.benchmark_name or "Evaluation"
 
-            # Build formatted output
             lines = [f"{'─' * 40}", f"  {name} Results", f"{'─' * 40}"]
             lines.append(f"  Prompts: {n_prompts}  Samples (n={self.n_samples_per_prompt}): {n_samples}")
             if n_skipped:

--- a/src/strands_env/eval/metrics.py
+++ b/src/strands_env/eval/metrics.py
@@ -16,15 +16,10 @@ def compute_pass_at_k(
     k_values: list[int],
     reward_threshold: float = 1.0,
 ) -> dict[str, float]:
-    """Compute pass@k metrics using unbiased estimator.
+    """Compute pass@k with the unbiased estimator, averaged across prompts.
 
-    Args:
-        results: Dict mapping prompt_id to list of samples.
-        k_values: List of k values for pass@k.
-        reward_threshold: Reward threshold for "pass" (default: 1.0).
-
-    Returns:
-        Dict mapping "pass@k" to average score.
+    A sample passes when its reward reaches `reward_threshold`. A prompt with fewer than k
+    samples is skipped rather than counted as a failure.
     """
     if not results:
         return {f"pass@{k}": 0.0 for k in k_values}

--- a/src/strands_env/eval/registry.py
+++ b/src/strands_env/eval/registry.py
@@ -68,11 +68,7 @@ def _discover_benchmarks() -> None:
 
 
 def get_benchmark(name: str) -> type[Evaluator[Any]]:
-    """Get a registered benchmark evaluator by name.
-
-    Args:
-        name: Benchmark name (e.g., `"aime-2024"`).
-    """
+    """Get a registered benchmark evaluator by name (e.g. `"aime-2024"`)."""
     _discover_benchmarks()
 
     if name not in _BENCHMARKS:
@@ -84,9 +80,8 @@ def get_benchmark(name: str) -> type[Evaluator[Any]]:
 def list_benchmarks() -> list[str]:
     """List all registered benchmark names.
 
-    Notes:
-        Benchmarks with missing dependencies will not appear in this list.
-        Use `list_unavailable_benchmarks()` to see them.
+    A benchmark whose module failed to import is absent here; `list_unavailable_benchmarks()`
+    reports those with their errors.
     """
     _discover_benchmarks()
     return sorted(_BENCHMARKS.keys())

--- a/src/strands_env/eval/reporter.py
+++ b/src/strands_env/eval/reporter.py
@@ -17,13 +17,13 @@ logger = logging.getLogger(__name__)
 class EvalReporter(ABC):
     """Base class for eval result reporters.
 
-    Notes:
-        The lifecycle (called by `Evaluator`) is as follows:
-        1. `log_sample(prompt_id, sample)` — after each completed sample (accumulate, fast)
-        2. `flush()` — periodic checkpoint (every save_interval completions + end of run)
-        3. `log_metrics(metrics)` — after `compute_metrics()` completes
-        4. `log_metadata(metadata)` — run-level params/tags (benchmark, model, backend, ...)
-        5. `publish()` — async; do all remote/heavy I/O here (S3 upload, MLflow, etc.)
+    `Evaluator` drives the lifecycle in this order:
+
+    1. `log_sample(prompt_id, sample)` — after each completed sample; accumulate, stay fast
+    2. `flush()` — periodic checkpoint, every `save_interval` completions and at end of run
+    3. `log_metrics(metrics)` — after `compute_metrics()`
+    4. `log_metadata(metadata)` — run-level params and tags (benchmark, model, backend)
+    5. `publish()` — async, and the only place for remote or heavy I/O
     """
 
     @abstractmethod
@@ -39,10 +39,8 @@ class EvalReporter(ABC):
     def rewrite(self, results: dict[str, list[EvalSample[Any]]]) -> None:
         """Reconcile the checkpoint to exactly `results`, dropping stale entries.
 
-        Notes:
-            Called once at resume time so retried (previously aborted) samples don't leave a
-            duplicate task entry behind. No-op for reporters that don't keep a rewritable local
-            checkpoint.
+        Called once at resume, so a retried (previously aborted) sample doesn't leave a duplicate
+        task entry behind. A no-op unless the reporter keeps a rewritable local checkpoint.
         """
         return None
 

--- a/src/strands_env/utils/aws.py
+++ b/src/strands_env/utils/aws.py
@@ -16,15 +16,10 @@ type BotoClientConfig = Config
 
 
 def resolve_region_name(region_name: str | None = None, profile_name: str | None = None) -> str:
-    """Resolve the AWS region name depending on the provided arguments.
+    """Resolve the AWS region name.
 
-    Args:
-        region_name: AWS region name. If `None`, resolved in order of precedence:
-            - `AWS_REGION` env var
-            - `AWS_DEFAULT_REGION` env var
-            - profile region from `~/.aws/config`
-            - `us-east-1` fallback
-        profile_name: Optional AWS profile name from `~/.aws/config`.
+    In order: the `region_name` argument, `AWS_REGION`, `AWS_DEFAULT_REGION`, the profile's region
+    from `~/.aws/config`, then `us-east-1`.
     """
     return (
         region_name
@@ -41,23 +36,16 @@ def get_session(
     role_arn: str | None = None,
     role_session_name: str = "strands-env",
 ) -> boto3.Session:
-    """Create a new boto3 session.
+    """Create a new boto3 session, resolving the region via `resolve_region_name`.
 
-    Args:
-        region_name: AWS region name. If `None`, resolved via `resolve_region_name`.
-        profile_name: Optional AWS profile name from `~/.aws/config`.
-        role_arn: Optional ARN of the IAM role to assume.
-        role_session_name: Session name for assumed role (only used if role_arn provided).
+    With `role_arn`, the role is assumed via STS with auto-refreshing credentials. Passing
+    `profile_name` too makes it a two-hop chain — the role is assumed *from that profile's*
+    credentials rather than the ambient ones, which is what a trust policy scoped to the profile's
+    account requires.
 
     Notes:
-        - Returns a **fresh** session every time — `boto3` sessions are not thread-safe,
-          so they must not be shared across concurrent calls. Use `get_client` instead
-          when you need a cached, thread-safe client.
-        - If `role_arn` is provided, assumes the role using STS with auto-refreshing
-          credentials via botocore's `RefreshableCredentials`. When `profile_name` is
-          also provided, the role is assumed **from that profile's credentials** (a
-          two-hop chain) rather than from the ambient ones — needed when the role's
-          trust policy only admits identities from the profile's account.
+        A **fresh** session every call. boto3 sessions are not thread-safe and must not be shared
+        across concurrent calls; use `get_client` when you want a cached, thread-safe client.
     """
     region_name = resolve_region_name(region_name=region_name, profile_name=profile_name)
     if role_arn:
@@ -116,24 +104,15 @@ def get_client(
     role_session_name: str = "strands-env",
     config: BotoClientConfig | None = None,
 ) -> BotoClient:
-    """Get a cached boto3 client.
+    """Get a cached boto3 client, one dedicated session per client.
 
-    Args:
-        service_name: AWS service name (e.g. `"bedrock-agentcore"`, `"lambda"`, `"dynamodb"`).
-        region_name: AWS region name. If `None`, resolved via `resolve_region_name`.
-        profile_name: Optional AWS profile name from `~/.aws/config`.
-        role_arn: Optional ARN of the IAM role to assume.
-        role_session_name: Session name for assumed role (only used if role_arn provided).
-        config: Optional `botocore.config.Config` for client-level settings
-            (e.g. `max_pool_connections`, `connect_timeout`, `read_timeout`, `retries`).
+    Each client owns its session, so nothing shares the non-thread-safe `Session` while the clients
+    themselves stay thread-safe. With `role_arn` the session uses `RefreshableCredentials`, so the
+    client keeps working past credential expiry.
 
     Notes:
-        - Cached by `(service_name, region_name, profile_name, role_arn, role_session_name)`.
-          `config` is excluded from the cache key (not hashable).
-        - Each client gets its own dedicated boto3 Session, avoiding the thread-safety
-          issues of sharing a Session across clients. The client itself is thread-safe.
-        - If `role_arn` is provided, the underlying Session uses `RefreshableCredentials`
-          so the client auto-refreshes when credentials expire.
+        `config` is excluded from the cache key because it isn't hashable — two calls that differ
+        only in `config` return the first one's client.
     """
     region_name = resolve_region_name(region_name=region_name, profile_name=profile_name)
     if role_arn:

--- a/src/strands_env/utils/decorators.py
+++ b/src/strands_env/utils/decorators.py
@@ -13,20 +13,9 @@ from typing import Any
 def requires_env(*env_vars: str) -> Callable[..., Any]:
     """Decorator that validates environment variables at call time.
 
-    Works with both sync and async functions, methods and standalone functions.
-
-    Notes:
-        For async tool methods, returns an error string on missing vars.
-        For sync functions, raises `EnvironmentError`.
-
-    Example:
-        class MyToolkit:
-            @tool
-            @requires_env("SERPER_API_KEY")
-            async def serper_search(self, query: str) -> str:
-                api_key = os.environ["SERPER_API_KEY"]
-                ...
-
+    Works on sync and async functions alike, whether methods or standalone. An async function
+    returns the error string on a missing var — that is what an agent tool wants, since the message
+    reaches the model. A sync function raises `OSError` instead.
     """
 
     def _check() -> str | None:
@@ -58,15 +47,10 @@ def requires_env(*env_vars: str) -> Callable[..., Any]:
 def cache_by(*key_args: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator that caches function results using only the specified arguments as the cache key.
 
-    Arguments not listed in `key_args` are still passed to the function but excluded
-    from the cache key, allowing unhashable arguments (dicts, lists, etc.) without
-    breaking the cache.
+    Arguments not named in `key_args` are still passed through but excluded from the key, which is
+    what lets an unhashable argument (a dict, a list) coexist with caching.
 
-    Args:
-        *key_args: Names of the function parameters to include in the cache key.
-
-    Example::
-
+    Example:
         @cache_by("service_name", "region")
         def get_client(service_name, region="us-east-1", **config_kwargs):
             ...
@@ -106,22 +90,17 @@ class TimeoutInterrupt(BaseException):
 def with_timeout(timeout: float | None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator that enforces a timeout on function execution.
 
-    Runs the wrapped function in a daemon thread. On timeout, injects
-    `_TimeoutInterrupt` into the thread (CPython best-effort) so the work
-    does not continue consuming resources.
+    Runs the wrapped function in a daemon thread and, on timeout, injects `TimeoutInterrupt` into
+    it (CPython best-effort) so the abandoned work stops consuming resources. `timeout=None` skips
+    the wrapper entirely.
 
-    This is useful when the function's own timeout mechanism relies on
-    `signal.alarm()` (which only works in the main thread). This decorator
-    works correctly in all threading contexts.
-
-    Args:
-        timeout: Timeout in seconds, or `None` to run without timeout.
+    Use this when the callee's own timeout relies on `signal.alarm()`, which only fires on the main
+    thread; this one works from any thread.
 
     Raises:
-        TimeoutError: If the function doesn't complete within `timeout` seconds.
+        TimeoutError: the function did not finish within `timeout` seconds.
 
-    Example::
-
+    Example:
         @with_timeout(5)
         def slow_computation():
             ...

--- a/src/strands_env/utils/loader.py
+++ b/src/strands_env/utils/loader.py
@@ -63,11 +63,7 @@ def load_function(name: str) -> Callable[..., Any]:
 
 
 def load_env_factory_hook(hook_path: str) -> EnvFactoryCreator:
-    """Load environment factory hook and return `create_env_factory` function.
-
-    Args:
-        hook_path: Dotted path to a module exporting `create_env_factory`.
-    """
+    """Return the `create_env_factory` exported by the module at `hook_path`."""
     try:
         return cast(EnvFactoryCreator, load_function(hook_path + ".create_env_factory"))
     except ValueError as e:
@@ -75,11 +71,7 @@ def load_env_factory_hook(hook_path: str) -> EnvFactoryCreator:
 
 
 def load_evaluator_hook(hook_path: str) -> type[Evaluator]:
-    """Load evaluator hook and return the `Evaluator` class.
-
-    Args:
-        hook_path: Dotted path to a module exporting `EvaluatorClass`.
-    """
+    """Return the `EvaluatorClass` exported by the module at `hook_path`."""
     try:
         return cast(type["Evaluator"], load_class(hook_path + ".EvaluatorClass"))
     except ValueError as e:

--- a/src/strands_env/utils/slime_logger.py
+++ b/src/strands_env/utils/slime_logger.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# NOTE: response_len in default logging refers to loss_mask=1 tokens
-
 
 class RolloutLogger:
     """Custom `slime` rollout logger with a pluggable logging backend.
@@ -76,9 +74,8 @@ class RolloutLogger:
     def log_rollout_metrics(self, samples: list[Sample], rollout_extra_metrics: dict | None) -> None:
         """Aggregate `RolloutResult.metrics` across samples into `rollout_extra_metrics`.
 
-        Note:
-            - Need to set `sample.metrics = result.metrics` in `generate()`
-            - Overrides for more custom rollout logging metrics can be added here
+        Reads `sample.result.metrics`, so `generate()` has to attach the `RolloutResult` as
+        `sample.result` first.
         """
         per_sample: dict[str, list[float]] = {
             "message_count": [],


### PR DESCRIPTION
File-by-file sweep, first two packages: **`core/` (7 files) and `utils/` (5 files)**. −147 lines, no behaviour change.

## The rule that made it mechanical

`D417` rejects a *partial* `Args:` section. So the question is never "does this parameter need a line" but **"do this function's parameters need explaining at all"** — usually no.

`aws.py` is the clearest case: `profile_name: Optional AWS profile name from ~/.aws/config.` appeared in three separate `Args:` blocks, each next to a `profile_name: str | None` annotation. All three blocks go. What they *surrounded* stays, because that part the signature can't carry — the two-hop STS chain, the fresh-session-per-call rule, the cache key.

**The opposite case, kept:** `EnvironmentActor.rollout` is `str -> str`, and only the prose says those strings are JSON envelopes you rebuild with `model_validate_json()`. The poorer the type, the more the section earns.

## Three docstrings were wrong, not just noisy

- **`requires_env`** claimed it raises `EnvironmentError`. The code raises `OSError` — same object since Python 3.3, so the behaviour was right and the name a decade stale.
- **`with_timeout`** said it injects `_TimeoutInterrupt`. The class is `TimeoutInterrupt`, no underscore; grepping the private name finds nothing.
- **`log_rollout_metrics`** said `generate()` must set `sample.metrics`. It reads `sample.result.metrics`. Doing what the docstring asked would not have made the method work.

## Structural moves

Class-level `Args:` describing `__init__` parameters moved onto `__init__`, kept in every case (`env_hook_path: str` doesn't say "dotted path to a callable returning an `AsyncEnvFactory`"; `judge_model: Model | list[Model]` doesn't say the list is round-robined once per sample).

`Environment.reset` had three unrelated facts under one `Notes:` — what `reset` is for, what `__init__` may not do, what `cleanup` must tolerate. The first two are *why the method exists* → body text. Only the teardown contract stays a footnote.

`resolve_region_name` had its four-level precedence list nested under the `region_name` parameter; that order is what the function does, not a property of one argument.

Also gone: a dangling `# NOTE: response_len ...` at the top of `slime_logger` (`response_len` appears nowhere in that file), and two Sphinx `Example::` double colons that nothing here renders.

## AGENTS.md

Gains the rules these decisions followed — including a correction: it claimed `Notes:` was the only section besides `Args:`, while the tree actually used **eight** (`Args:` 37, `Notes:` 28, `Returns:` 11, `Yields:` 9, `Example:` 3, `Raises:` 2, `Note:` 1, `Examples:` 1). Each is now either justified or banned.

I checked comparable projects before writing it down: `httpx` uses **zero** structured sections, `openai-agents` uses `Args:` on ~3% of defs. We were at **14%**.

## CLAUDE.md → symlink

Was a one-line `@AGENTS.md` include, now a real symlink (git mode `120000`), so any tool reading `CLAUDE.md` gets the content without knowing that syntax. Verified GitHub dereferences it. Same as openai-agents.

## Remaining

`eval/` (21 files) and `environments/` (37) in later PRs.