### PR TITLE
docs: align the project tagline

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "Please cite strands-env if you use this code in your own work."
-title: "Standardizing environment infrastructure with Strands Agents — step, observe, reward."
+title: "strands-env: A unified framework for building agentic RL environments."
 authors:
-  - family-names: "Yuan"
-    given-names: "He"
+  - family-names: "He"
+    given-names: "Yuan"
 license: Apache-2.0
 url: "https://github.com/strands-rl/strands-env/"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/strands-rl/strands-env)
 
-A framework for building agent environments for RL training and evaluation with Strands Agents.
+A unified framework for building agent environments for RL training and evaluation with Strands Agents.
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "strands-env"
 dynamic = ["version"]
-description = "A framework for building agent environments with Strands Agents."
+description = "A unified framework for building agent environments with Strands Agents."
 authors = [{name = "Yuan He", email = "yuanhe.cs.ai@gmail.com"}]
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Why

The one-line description of this project said three different things depending on where you read it, and `CITATION.cff` cited an API that no longer exists.

## Tagline

`unified` was missing from the PyPI metadata and the GitHub repo description:

| Where | Before | After |
|---|---|---|
| `README.md` | A framework for building agent environments for RL training and evaluation with Strands Agents. | **A unified framework** for building agent environments for RL training and evaluation with Strands Agents. |
| `pyproject.toml` (PyPI page) | A framework for building agent environments with Strands Agents. | **A unified framework** for building agent environments with Strands Agents. |
| `CITATION.cff` | Standardizing environment infrastructure with Strands Agents — step, observe, reward. | strands-env: A unified framework for building agentic RL environments. |
| GitHub repo description | A framework for building agent environments for RL training and evaluation with Strands Agents. | **A unified framework** for building agent environments for RL training and evaluation with Strands Agents. |

The repo description is a settings field rather than a tracked file, so it is already updated — it is listed here for the record.

## CITATION.cff

Two separate errors:

- **The title cited a retired API.** `step, observe, reward` has not described this package since #160 (flattened `Observation` into `RolloutResult`, renamed `step` → `rollout`) and #171 (`rollout` owns the whole episode lifecycle). `Observation`, `def step` and `StepResult` no longer appear anywhere in `src/`. The new title also takes the `strands-env: ...` prefix so the package name is visible in a reference list, matching `strands-sglang`'s citation.
- **`family-names` and `given-names` were swapped**, so the entry rendered as "Yuan, H." instead of "He, Y.".