### PR TITLE
build: drop ruff's fix = true, and pin the target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ default-groups = ["dev"]
 
 [tool.ruff]
 line-length = 120
-fix = true
+target-version = "py312"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## `fix = true`

`fix = true` under `[tool.ruff]` applies to `ruff check`, not just the formatter. On an autofixable violation the check rewrites the file, reports "1 fixed", and **exits 0**.

#217 addressed this in the pre-commit hook (`- id: ruff` → `ruff-check` with `--exit-non-zero-on-fix`) but left the `pyproject.toml` setting in place, where it has been since the initial commit. CI runs the hooks, so the gate itself was never blind — but a hand-run `ruff check src/` silently edits the tree and reports success, which is how the setting survived review twice.

Nothing was hiding behind it: `ruff check src/ tests/ examples/` passes with the setting removed, and no file is modified.

## `target-version`

Ruff was inferring the target from `requires-python = ">=3.12"`. Stating `py312` explicitly keeps the lint target from following that floor if it ever moves for a packaging reason rather than a syntax one.

## Not in this PR

`utils/slime_logger.py:232` passes a `list[dict]` to `mlflow.log_dict`, whose annotation is `dict[str, Any]`. mypy cannot see it here because `mlflow` is not installed and is covered by an `ignore_missing_imports` override, so the module resolves to `Any`. It runs correctly (`log_dict` is `json.dump` under the hood, and the annotation is narrower than the documented contract), so it is a typing fix rather than a bug fix — it gets its own change.