### PR TITLE
fix(slime): type the mlflow artifact payload for installs that ship stubs

### DIFF
--- a/src/strands_env/utils/slime_logger.py
+++ b/src/strands_env/utils/slime_logger.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from slime.rollout.sglang_rollout import GenerateState  # type: ignore
 from slime.utils.metric_utils import compute_rollout_step, compute_statistics, dict_add_prefix  # type: ignore
@@ -229,6 +229,8 @@ class RolloutLogger:
         if not rows:
             return
 
-        mlflow.log_dict(rows, f"rollout_samples/step_{step:05d}.json")
+        # `log_dict` is annotated `dict[str, Any]` but documents a JSON-serializable object and
+        # json.dumps whatever it gets; a list of rows is the artifact shape we want.
+        mlflow.log_dict(cast(dict[str, Any], rows), f"rollout_samples/step_{step:05d}.json")
 
         logger.info("Logged %d samples to MLflow (rollout %d, step %d)", len(rows), rollout_id, step)


### PR DESCRIPTION
Split out of #246 — that PR was merged before this commit reached the branch, so the change was left behind.

## What

`_log_samples_mlflow` passes its list of sample rows to `mlflow.log_dict`, which is annotated `dict[str, Any]`. The annotation is narrower than both the documented contract ("JSON/YAML-serializable object") and the implementation (`json.dump` on whatever it receives).

The list is the artifact shape we want, and it works. Verified by calling it against a real mlflow 3.10.1 rather than by reading the source:

```python
mlflow.log_dict([{"a": 1, "prompt": "x"}, {"a": 2, "prompt": "y"}], "rollout_samples/step_00001.json")
```
```json
[
  {"a": 1, "prompt": "x"},
  {"a": 2, "prompt": "y"}
]
```

## Why mypy doesn't catch it here

mlflow is training-only: not installed in this repo, and named in an `ignore_missing_imports` override. The module resolves to `Any`, so the call goes unchecked. Anywhere mlflow *is* installed, that line is an `arg-type` error.

## Why `cast` and not `# type: ignore[arg-type]`

The ignore cannot satisfy both environments, which I confirmed by trying it: with mlflow absent the comment is unused and `warn_unused_ignores = true` fails on it. `cast` is inert either way.

Wrapping the rows in a dict was not an option — that changes the artifact format.

## Verification

`pre-commit run --all-files` clean. `mypy src/strands_env` clean here; the same file also type-checks clean under an interpreter that has mlflow installed, which is the case this fix is for.