### PR TITLE
fix(core): keep mypy from calling the actor-pool method bodies unreachable

### DIFF
--- a/src/strands_env/core/distributed.py
+++ b/src/strands_env/core/distributed.py
@@ -4,7 +4,7 @@ import asyncio
 import itertools
 import logging
 import subprocess
-from typing import Any
+from typing import Any, cast
 
 import ray
 from ray.actor import ActorHandle
@@ -112,16 +112,16 @@ class EnvironmentActorPool:
         Uses `asyncio.to_thread(ray.get, ...)` to avoid blocking the
         caller's event loop.
         """
-        actor = next(self.cycle)
+        actor: Any = next(self.cycle)
         obj_ref = actor.rollout.remote(task.model_dump_json())
-        result_json: str = await asyncio.to_thread(ray.get, obj_ref)
+        result_json = cast(str, await asyncio.to_thread(ray.get, obj_ref))
         return RolloutResult.model_validate_json(result_json)
 
     async def compute_reward(self, task: Task, result: RolloutResult) -> RewardResult:
         """Recompute reward for an existing rollout on the next available actor."""
-        actor = next(self.cycle)
+        actor: Any = next(self.cycle)
         obj_ref = actor.compute_reward.remote(task.model_dump_json(), result.model_dump_json())
-        result_json: str = await asyncio.to_thread(ray.get, obj_ref)
+        result_json = cast(str, await asyncio.to_thread(ray.get, obj_ref))
         return RewardResult.model_validate_json(result_json)
 
     def shutdown(self) -> None:


### PR DESCRIPTION
## Problem

`EnvironmentActorPool.rollout` and `EnvironmentActorPool.compute_reward` in `src/strands_env/core/distributed.py` both bind `actor` out of `itertools.cycle[ActorHandle]` and then reach through it:

```python
actor = next(self.cycle)
obj_ref = actor.rollout.remote(task.model_dump_json())
result_json: str = await asyncio.to_thread(ray.get, obj_ref)
```

Ray ships `py.typed`, and `ActorHandle.__getattr__` is annotated `(self, item: str) -> Never`. That tells mypy `actor.rollout` never returns, so every statement after it is unreachable and `obj_ref` has no inferable type. Four errors across the two methods:

```
Need type annotation for "obj_ref"  [var-annotated]
Statement is unreachable  [unreachable]
```

## Fix

Widen `actor` to `Any` so `Never` stays out of the flow analysis, and put the `str` on the `ray.get` result via `cast` rather than on the assignment target:

```python
actor: Any = next(self.cycle)
obj_ref = actor.rollout.remote(task.model_dump_json())
result_json = cast(str, await asyncio.to_thread(ray.get, obj_ref))
```

Annotating `obj_ref` on its own would not help — the unreachability starts upstream of it — so no `ObjectRef` import is added. Runtime behaviour is unchanged; this is types only.

## Verification

This is a fix for installs where ray is present. This repo does not install ray and maps `ray.*` to `Any` under `ignore_missing_imports` in `[[tool.mypy.overrides]]`, so `mypy src/strands_env` reports nothing here — clean both before and after, and it cannot demonstrate the fix. The four errors and their disappearance were confirmed in a separate checkout with ray 2.57.0 installed, not in this one.

`pre-commit run --all-files` is clean.