### PR TITLE
fix(models): treat a Bedrock tool_use stop with no tool-use block as end_turn

### DIFF
--- a/src/strands_env/core/models.py
+++ b/src/strands_env/core/models.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, override
 
 import boto3
 import botocore.config
 import httpx
 from strands.models import Model
-from strands.models.bedrock import BedrockModel
+from strands.models.bedrock import BedrockModel as _BedrockModel
 from strands.models.openai import OpenAIModel
 from strands.models.openai_responses import OpenAIResponsesModel
+from strands.types.streaming import StreamEvent
 from strands_sglang import SGLangClient, SGLangModel, get_client, get_tokenizer
 from strands_sglang.tool_parsers import HermesToolParser, ToolParser, get_tool_parser
 from transformers import PreTrainedTokenizerBase
@@ -97,6 +98,21 @@ DEFAULT_BOTO_CLIENT_CONFIG = botocore.config.Config(
 )
 
 
+class BedrockModel(_BedrockModel):
+    """Patching Strands' `BedrockModel` because Bedrock's API reports `tool_use` with no tool-use block."""
+
+    @override
+    async def stream(self, *args: Any, **kwargs: Any) -> AsyncGenerator[StreamEvent, None]:
+        saw_tool_use = False
+        async for event in super().stream(*args, **kwargs):
+            if "toolUse" in event.get("contentBlockStart", {}).get("start", {}):
+                saw_tool_use = True
+            elif (stop := event.get("messageStop")) and stop["stopReason"] == "tool_use" and not saw_tool_use:
+                yield {**event, "messageStop": {**stop, "stopReason": "end_turn"}}
+                continue
+            yield event
+
+
 def bedrock_model_factory(
     *,
     model_id: str,
@@ -119,7 +135,7 @@ def bedrock_model_factory(
         model_id=model_id,
         boto_session=boto_session,
         boto_client_config=boto_client_config,
-        streaming=False,
+        streaming=True,
         **sampling_params,
     )
 


### PR DESCRIPTION
## Problem

Bedrock sometimes closes a **text-only** message with `messageStop.stopReason == "tool_use"` while never emitting a `contentBlockStart` carrying `toolUse`. The SDK takes that stop reason at face value:

- `strands/event_loop/event_loop.py` → `if stop_reason == "tool_use": ... _handle_tool_execution(...)`
- inside it, `tool_uses = [content["toolUse"] for content in message["content"] if "toolUse" in content]` → **empty**
- the `finally` block still appends `{"role": "user", "content": []}` (a tool-result message with zero results) and the loop recurses into the model

So the next Converse request carries an empty content block, and a turn the model meant to end takes the rollout down instead.

The SDK already repairs the *mirror* artifact — `end_turn` arriving alongside a tool-use block gets promoted to `tool_use` in `strands.event_loop.streaming.handle_message_stop` — but nothing handles the reverse direction.

## Fix

A local `BedrockModel` subclass of `strands.models.bedrock.BedrockModel` (imported as `_BedrockModel`, so the exported name and `bedrock_model_factory` below it are untouched). It tracks whether a tool-use content block went past, and when `messageStop` says `tool_use` without one, re-yields the event with the reason rewritten to `end_turn`. Every other event passes through unchanged.

Both Bedrock paths funnel through `BedrockModel.stream`, so this covers streaming (`converse_stream`) and non-streaming alike (`converse` → `convert_non_streaming_to_streaming` emits the same `contentBlockStart`/`messageStop` shapes).

Also drops the `streaming=False` override in `bedrock_model_factory` for `streaming=True`, the SDK default.

## Verification

- `mypy src/strands_env` — clean, 71 files
- `ruff check src/ tests/` + `ruff format --check src/ tests/` — clean
- `pytest tests/unit/ -q` — 315 passed

No unit test for the new `stream()` override yet: the existing `TestBedrockModelFactory` cases patch `BedrockModel` wholesale, so exercising the patch needs a fake upstream `stream()`. Happy to add it here if you'd like it in this PR.