### PR TITLE
refactor(utils): keep the wrapped signature on cache_by via ParamSpec

### DIFF
--- a/src/strands_env/utils/decorators.py
+++ b/src/strands_env/utils/decorators.py
@@ -7,7 +7,10 @@ import os
 import threading
 from collections.abc import Callable
 from functools import wraps
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def requires_env(*env_vars: str) -> Callable[..., Any]:
@@ -44,11 +47,12 @@ def requires_env(*env_vars: str) -> Callable[..., Any]:
     return decorator
 
 
-def cache_by(*key_args: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+def cache_by(*key_args: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator that caches function results using only the specified arguments as the cache key.
 
     Arguments not named in `key_args` are still passed through but excluded from the key, which is
-    what lets an unhashable argument (a dict, a list) coexist with caching.
+    what lets an unhashable argument (a dict, a list) coexist with caching. The wrapper keeps the
+    decorated function's signature, so callers are type-checked against it.
 
     Example:
         @cache_by("service_name", "region")
@@ -56,12 +60,12 @@ def cache_by(*key_args: str) -> Callable[[Callable[..., Any]], Callable[..., Any
             ...
     """
 
-    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-        cache: dict[tuple, Any] = {}
+    def decorator(fn: Callable[P, R]) -> Callable[P, R]:
+        cache: dict[tuple[Any, ...], R] = {}
         sig = inspect.signature(fn)
 
         @wraps(fn)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             # Resolve positional/keyword args to param names and fill defaults,
             # so e.g. f("s3") and f(service_name="s3") produce the same key.
             bound = sig.bind(*args, **kwargs)


### PR DESCRIPTION
## Problem

`cache_by` was typed `Callable[[Callable[..., Any]], Callable[..., Any]]`, so every function it decorates loses its signature to mypy. For `get_client` in `utils/aws.py`:

```
$ mypy -c 'from strands_env.utils.aws import get_client; reveal_type(get_client); get_client("s3", 123)'
note: Revealed type is "def (*Any, **Any) -> Any"
Success: no issues found
```

Callers are not checked against `get_client`'s parameters, and the client they get back is `Any`, so any method call on it is unchecked too.

## Fix

Type the decorator with `ParamSpec`/`TypeVar` so `Callable[P, R]` goes in and comes out. The wrapper takes `*args: P.args, **kwargs: P.kwargs` and returns `R`; the cache is `dict[tuple[Any, ...], R]`. The docstring says the wrapper keeps the decorated function's signature.

Same check after the change:

```
note: Revealed type is "def (service_name: str, region_name: str | None =, profile_name: str | None =, role_arn: str | None =, role_session_name: str =, config: botocore.config.Config | None =) -> botocore.client.BaseClient"
error: Argument 2 to "get_client" has incompatible type "int"; expected "str | None"  [arg-type]
```

No runtime change. The two `# type: ignore[attr-defined]` lines for `wrapper.cache` / `wrapper.cache_clear` stay, since a plain function object has no such attributes either way.

## Verification

- `pre-commit run --all-files` — all hooks pass (ruff check/format, mypy, pytest fast)
- `pytest tests/unit/ -q` — 315 passed
