### PR TITLE
feat(models): pass reasoning to Bedrock Converse per model family

### DIFF
--- a/src/strands_env/core/models.py
+++ b/src/strands_env/core/models.py
@@ -119,6 +119,7 @@ def bedrock_model_factory(
     boto_session: boto3.Session,
     boto_client_config: botocore.config.Config = DEFAULT_BOTO_CLIENT_CONFIG,
     sampling_params: dict[str, Any] = DEFAULT_SAMPLING_PARAMS,
+    additional_request_fields: dict[str, Any] | None = None,
 ) -> ModelFactory:
     """Return a factory that creates `BedrockModel` instances.
 
@@ -126,6 +127,8 @@ def bedrock_model_factory(
         - One boto3 session, one boto3 client. The client is thread-safe, so it is built once and
           shared; `BedrockModel` won't accept a pre-built one, hence the pilot instance below.
         - `max_new_tokens` is remapped to `max_tokens` for the Bedrock API.
+        - `additional_request_fields` goes into the Converse request as-is (reasoning, thinking);
+          `ModelConfig.bedrock_request_fields` builds it per model family.
     """
     sampling_params = dict(sampling_params)
     if "max_new_tokens" in sampling_params:
@@ -138,6 +141,8 @@ def bedrock_model_factory(
         streaming=True,
         **sampling_params,
     )
+    if additional_request_fields:
+        model_kwargs["additional_request_fields"] = additional_request_fields
 
     # Build one model to extract a properly configured, thread-safe client.
     shared_client = BedrockModel(**model_kwargs).client
@@ -255,7 +260,8 @@ class ModelConfig:
     profile_name: str | None = None
     role_arn: str | None = None
 
-    # Bedrock Mantle (GPT via OpenAI Responses API): reasoning config, e.g. {"effort": "high"}.
+    # Reasoning config, e.g. {"effort": "high"}. Bedrock Mantle passes it to the Responses API;
+    # Bedrock translates it per model family (`bedrock_request_fields`).
     reasoning: dict[str, Any] | None = None
 
     # Sampling
@@ -264,6 +270,29 @@ class ModelConfig:
     def to_dict(self) -> dict:
         """Convert to dict for serialization."""
         return dataclasses.asdict(self)
+
+    def bedrock_request_fields(self) -> dict[str, Any] | None:
+        """Translate `reasoning` into the Converse `additionalModelRequestFields` this model family takes.
+
+        OpenAI models take `reasoning` as-is (`{"effort": ...}`); their reasoning comes back as
+        `redactedContent`, retained across turns but not readable. Claude 5 models reject
+        `thinking.enabled` and take adaptive thinking with `output_config.effort`; their reasoning comes
+        back as a summary with a signature. Older Claude models (a `thinking.enabled` budget) are not mapped.
+
+        Returns:
+            `None` when `reasoning` is unset or the family is unknown, so the request is unchanged.
+        """
+        if not self.reasoning or not self.model_id:
+            return None
+        if "openai." in self.model_id:
+            return {"reasoning": self.reasoning}
+        if "anthropic." in self.model_id:
+            # Without `display` Bedrock returns the thinking block with empty text; `summarized` fills it.
+            fields: dict[str, Any] = {"thinking": {"type": "adaptive", "display": "summarized"}}
+            if effort := self.reasoning.get("effort"):
+                fields["output_config"] = {"effort": effort}
+            return fields
+        return None
 
 
 def build_model_factory(config: ModelConfig | dict[str, Any]) -> ModelFactory:
@@ -296,7 +325,10 @@ def build_model_factory(config: ModelConfig | dict[str, Any]) -> ModelFactory:
                 role_arn=config.role_arn,
             )
             return bedrock_model_factory(
-                model_id=config.model_id, boto_session=boto_session, sampling_params=config.sampling_params
+                model_id=config.model_id,
+                boto_session=boto_session,
+                sampling_params=config.sampling_params,
+                additional_request_fields=config.bedrock_request_fields(),
             )
         case "bedrock-mantle":
             if not config.model_id:

--- a/src/strands_env/eval/cli.py
+++ b/src/strands_env/eval/cli.py
@@ -124,7 +124,7 @@ def _list_benchmarks(ctx: click.Context, param: click.Parameter, value: bool) ->
     "--reasoning-effort",
     type=click.Choice(["low", "medium", "high"]),
     default=None,
-    help="Reasoning effort for Bedrock Mantle GPT models (maps to reasoning={'effort': ...}).",
+    help="Reasoning effort, as reasoning={'effort': ...}: Bedrock Mantle GPT models, and on Bedrock OpenAI models (reasoning.effort) and Claude 5 models (adaptive thinking, output_config.effort).",
 )
 @click.option("--tool-parser", type=str, default=None, help="Tool parser name (e.g., 'hermes', 'qwen_xml').")
 # Sampling params

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -75,6 +75,55 @@ class TestBedrockModelFactory:
         assert model1.client is model2.client
         assert model1.client is mock_client
 
+    @patch("strands_env.core.models.BedrockModel")
+    def test_forwards_additional_request_fields(self, mock_bedrock_cls):
+        bedrock_model_factory(
+            model_id="test",
+            boto_session=MagicMock(spec=boto3.Session),
+            additional_request_fields={"reasoning": {"effort": "low"}},
+        )
+        assert mock_bedrock_cls.call_args[1]["additional_request_fields"] == {"reasoning": {"effort": "low"}}
+
+    @patch("strands_env.core.models.BedrockModel")
+    def test_omits_request_fields_when_unset(self, mock_bedrock_cls):
+        bedrock_model_factory(model_id="test", boto_session=MagicMock(spec=boto3.Session))
+        assert "additional_request_fields" not in mock_bedrock_cls.call_args[1]
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig.bedrock_request_fields
+# ---------------------------------------------------------------------------
+
+
+class TestBedrockRequestFields:
+    def test_unset_reasoning(self):
+        config = ModelConfig(backend="bedrock", model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
+        assert config.bedrock_request_fields() is None
+
+    def test_openai_passes_reasoning_through(self):
+        config = ModelConfig(backend="bedrock", model_id="openai.gpt-oss-120b-1:0", reasoning={"effort": "high"})
+        assert config.bedrock_request_fields() == {"reasoning": {"effort": "high"}}
+
+    def test_claude_takes_adaptive_thinking(self):
+        config = ModelConfig(
+            backend="bedrock", model_id="global.anthropic.claude-sonnet-5-20260501-v1:0", reasoning={"effort": "high"}
+        )
+        assert config.bedrock_request_fields() == {
+            "thinking": {"type": "adaptive", "display": "summarized"},
+            "output_config": {"effort": "high"},
+        }
+
+    def test_unknown_family_is_unchanged(self):
+        config = ModelConfig(backend="bedrock", model_id="amazon.nova-pro-v1:0", reasoning={"effort": "high"})
+        assert config.bedrock_request_fields() is None
+
+    @patch("strands_env.core.models.get_session")
+    @patch("strands_env.core.models.BedrockModel")
+    def test_build_model_factory_wires_reasoning(self, mock_bedrock_cls, mock_get_session):
+        config = ModelConfig(backend="bedrock", model_id="openai.gpt-oss-120b-1:0", reasoning={"effort": "low"})
+        build_model_factory(config)
+        assert mock_bedrock_cls.call_args[1]["additional_request_fields"] == {"reasoning": {"effort": "low"}}
+
 
 # ---------------------------------------------------------------------------
 # bedrock_mantle_model_factory


### PR DESCRIPTION
## Problem

`ModelConfig.reasoning` (and the CLI's `--reasoning-effort`) was only honoured by the `bedrock-mantle` backend, which hands it to the OpenAI Responses API. On the `bedrock` backend it was accepted and silently dropped, so a Converse-served reasoning model ran with reasoning off.

Converse takes reasoning through `additionalModelRequestFields`, and the shape is per model family:

- **OpenAI models** take `reasoning` as-is (`{"effort": ...}`). Their reasoning comes back as `redactedContent`, retained across turns but not readable.
- **Claude 5 models** reject `thinking.enabled` and take adaptive thinking with `output_config.effort`. Without `thinking.display`, Bedrock returns the thinking block with empty text and only a signature, so the record carried no readable reasoning; `display: "summarized"` fills it with the model's summary (`omitted` is the only other value).
- **Older Claude models** (a `thinking.enabled` budget) are not mapped, so their requests are unchanged.

## Fix

- `ModelConfig.bedrock_request_fields()` translates `reasoning` into the `additionalModelRequestFields` the model family takes, returning `None` when `reasoning` is unset or the family is unknown.
- `bedrock_model_factory` gains `additional_request_fields`, forwarded to `BedrockModel` as-is; `build_model_factory` wires the two together for the `bedrock` backend.
- `--reasoning-effort` help text now names the backends it reaches.

## Verification

- `mypy src/strands_env` — clean, 71 files
- `ruff check` + `ruff format --check` — clean
- `pre-commit run --all-files` — all hooks pass
- `pytest tests/unit/ -q` — 323 passed, including 7 new cases: per-family translation (OpenAI / Claude 5 / unknown / unset), factory forwarding and omission, and `build_model_factory` wiring.
