### PR TITLE
fix(eval): write bytes in results.jsonl as base64

### DIFF
--- a/src/strands_env/eval/reporter.py
+++ b/src/strands_env/eval/reporter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -142,7 +143,7 @@ class LocalReporter(EvalReporter):
         fh = self._ensure_open()
         data = sample.model_dump()
         data["prompt_id"] = prompt_id
-        fh.write(json.dumps(data) + "\n")
+        fh.write(json.dumps(data, default=lambda b: base64.b64encode(b).decode()) + "\n")
 
     def flush(self) -> None:
         """Sync the open file handle to disk."""
@@ -164,7 +165,7 @@ class LocalReporter(EvalReporter):
                 for sample in samples:
                     data = sample.model_dump()
                     data["prompt_id"] = prompt_id
-                    f.write(json.dumps(data) + "\n")
+                    f.write(json.dumps(data, default=lambda b: base64.b64encode(b).decode()) + "\n")
 
     def log_metrics(self, metrics: dict[str, float]) -> None:
         """Write `metrics.json` to the output directory."""

--- a/tests/unit/eval/test_reporter.py
+++ b/tests/unit/eval/test_reporter.py
@@ -71,6 +71,22 @@ class TestLocalReporter:
         rows = _read_jsonl(output_path)
         assert rows[0]["task"]["message"] == "half a math-italic code point: \ud835"
 
+    def test_writes_bytes_as_base64(self, tmp_path: Path):
+        """Bedrock returns redacted reasoning as bytes, which json.dumps rejects."""
+        output_path = tmp_path / "results.jsonl"
+        reporter = LocalReporter(output_path)
+        redacted = {"role": "assistant", "content": [{"reasoningContent": {"redactedContent": b"\x00\x01"}}]}
+        sample = EvalSample(task=Task(id="p1_0", message="q1"), result=RolloutResult(messages=[redacted]))
+
+        reporter.log_sample("p1", sample)
+        reporter.flush()
+        rows = _read_jsonl(output_path)
+        assert rows[0]["result"]["messages"][0]["content"][0]["reasoningContent"]["redactedContent"] == "AAE="
+
+        reporter.rewrite({"p1": [sample]})
+        rows = _read_jsonl(output_path)
+        assert rows[0]["result"]["messages"][0]["content"][0]["reasoningContent"]["redactedContent"] == "AAE="
+
     def test_log_sample_creates_parent_dirs(self, tmp_path: Path):
         """The first log_sample creates parent directories if they don't exist."""
         output_path = tmp_path / "nested" / "dir" / "results.jsonl"


### PR DESCRIPTION
## Problem

A reasoning model served through Bedrock Converse returns its redacted reasoning as `bytes` inside the messages (`reasoningContent.redactedContent`). `LocalReporter` wrote each sample with a plain `json.dumps`, which rejects `bytes`, so the eval died on its first sample.

## Fix

`LocalReporter.log_sample` and `LocalReporter.rewrite` pass `default=` to `json.dumps` that base64-encodes `bytes`. The record stays complete and replayable; every other unserializable type still raises as before.

## Verification

- `ruff check` + `ruff format --check` — clean
- `pre-commit run --all-files` — all hooks pass
- `pytest tests/unit/ -q` — 323 passed, including a new round-trip case that writes `b"\x00\x01"` through both `log_sample` and `rewrite` and reads back `"AAE="`.
