### PR TITLE
fix(eval): log the traceback when a sample aborts

### DIFF
--- a/src/strands_env/eval/evaluator.py
+++ b/src/strands_env/eval/evaluator.py
@@ -177,7 +177,7 @@ class Evaluator(Generic[TaskT]):
                 logger.warning("[%s]: sample aborted by validate_sample", task.id)
             return sample
         except Exception as e:
-            logger.error("[%s]: evaluate_sample failed, aborting: %s", task.id, e)
+            logger.exception("[%s]: evaluate_sample failed, aborting: %s", task.id, e)
             return EvalSample(task=task, result=RolloutResult(), aborted=True)
 
     async def run(self, tasks: Iterable[TaskT]) -> dict[str, list[EvalSample[TaskT]]]:


### PR DESCRIPTION
## Problem

`Evaluator.evaluate_sample` catches every exception from the rollout and marks the sample aborted, but it logged only `str(e)`. A rollout that died inside an env, a tool, or a reward left a one-line message with no indication of where it failed, so diagnosing an aborted eval meant re-running it under a debugger.

## Fix

The handler uses `logger.exception` instead of `logger.error`. Same message, same ERROR level, with the traceback appended. The aborted `EvalSample` and the resume behaviour are unchanged. Matches how `HarborReward` already logs its verifier failures.

## Verification

- `pre-commit run --all-files` — all hooks pass (incl. `mypy`, `pytest (fast)`)
- `pytest tests/unit/eval -q` — 71 passed
